### PR TITLE
Added support for waiting on digital input and output state change events

### DIFF
--- a/piControl.h
+++ b/piControl.h
@@ -70,6 +70,8 @@
 
 #define  KB_WAIT_FOR_EVENT		_IO(KB_IOC_MAGIC, 50 )  // wait for an event. This call is normally blocking
 #define  KB_EVENT_RESET			1		// piControl was reset, reload configuration
+#define  KB_EVENT_DINPUT_CHANGED	2		// piControl digital input state was changed
+#define  KB_EVENT_DOUTPUT_CHANGED	3		// piControl digital output state was changed
 
 // the following call are for KUNBUS internal use only. uncomment the following define to activate them.
 // #define KUNBUS_TEST

--- a/piControlMain.h
+++ b/piControlMain.h
@@ -38,6 +38,8 @@ typedef enum
 typedef enum piEvent
 {
 	piEvReset = 1,
+	piEvDIChanged = 2,
+	piEvDOChanged = 3,
 } enPiEvent;
 
 


### PR DESCRIPTION
Hi,

in our testing environment we found through measurements that a lot of CPU time is wasted unnecessarily `read()`ing the piControl0 device node even when none of the digital inputs or outputs (which in our case is the only module we are currently testing) are changed. The piControl driver already periodically communicates with all attached modules and we would only double the amount of work that had to be done if we had to poll the piControl driver itself with the same frequency.

I noticed that work had been started on making use of a blocking `ioctl()` call to wait on certain events from userspace. I extended the functionality to not only support waiting on device resets but also waiting on digital IO changes which is currently the only event relevant to us.

This isn't as elegant of an approach as I had hoped for but it gets the job done and saves CPU time. A cleaner solution would be to support true IO multiplexing via `select()`/`epoll()` that we can integrate with the other file descriptors we are also watching for change notification, however this requires a bigger change to the driver code which I didn't want to undertake myself.

I figured that this addition might be beneficial to other users as well especially if they have similar runtime requirements as we do.

Feedback is appreciated.