### PR TITLE
piControl: add missing lock

### DIFF
--- a/piControlMain.c
+++ b/piControlMain.c
@@ -863,9 +863,9 @@ static long piControlIoctl(struct file *file, unsigned int prg_nr, unsigned long
 			if (spi_val.i16uAddress >= KB_PI_LEN) {
 				status = -EFAULT;
 			} else {
-				// bei einem Byte braucht man keinen Lock rt_mutex_lock(&piDev_g.lockPI);
+				rt_mutex_lock(&piDev_g.lockPI);
 				val = piDev_g.ai8uPI[spi_val.i16uAddress];
-				// bei einem Byte braucht man keinen Lock rt_mutex_unlock(&piDev_g.lockPI);
+				rt_mutex_unlock(&piDev_g.lockPI);
 
 				if (spi_val.i8uBit >= 8) {
 					spi_val.i8uValue = val;


### PR DESCRIPTION
As a comment implies the author of the code did not see the requirement of
locking the copy of a byte value in case of the KB_GET_VALUE ioctl.
Unfortunately this assumption is wrong:
In case of two threads A (writer) and B (reader) that access the same data
we have to ensure memory coherency. Thus for thread A we must ensure that
the written value actually is written to its RAM destination and not held
in cache. For thread B we must ensure that the value is actually read from
RAM and not from cache. Since the spinlock lock()/unlock() operations imply
the required memory barriers both can be achieved by using spinlocks.

The writer already uses a spinlock to access the data. Use this for the
reader, too.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>