### PR TITLE
piControl:flat: Specify module dependencies

### DIFF
--- a/piControlMain.c
+++ b/piControlMain.c
@@ -85,7 +85,8 @@ MODULE_SOFTDEP("pre: bcm2835-thermal "	/* cpu temp in process image */
 	       "mux_gpio "		/* compact ain mux */
 	       "iio_mux "		/* compact ain mux */
 	       "mcp320x "		/* compact ain */
-	       "ti-dac082s085");	/* compact aout */
+	       "ti-dac082s085 "		/* compact aout */
+	       "ad5446");		/* flat aout */
 
 /******************************************************************************/
 /******************************  Prototypes  **********************************/


### PR DESCRIPTION
On the flat the module piControl depends on ad5446 which it uses for analog
output. However starting piControl on bootup may fail due to ad5446 not
being present at this time.
The reason is that there is that programs like modprobe do not know about
this module dependeny.
So give modprobe a hint by adding ad5446 to the list of modules specified
in MODULE_SOFTDEP.

Reported-by: Simon Han <z.han@kunbus.de>
Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>