### PR TITLE
piControl:flat: Add initial support for MultiIO module

### DIFF
--- a/IoProtocol.h
+++ b/IoProtocol.h
@@ -465,4 +465,166 @@ struct      // IOP_TYP1_CMD_DATA5
 SAioScalingResponse;
 
 //-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+// ----------------- MULTI IO modules -------------------------------------
+//-----------------------------------------------------------------------------
+
+#pragma pack(push,1)
+
+typedef enum
+{
+    MIO_NOP = 0,
+    MIO_CALIBRATION_AINPUTS_P0 = 1,
+    MIO_CALIBRATION_AINPUTS_P1 = 2,
+    MIO_CALIBRATION_AOUTPUTS   = 3,
+    MIO_CALIBRATION_SAVE = 4,
+} EMioCalibrationModes;
+
+#define MIO_PWM_TMR_CNT 	3
+#define MIO_DIO_PORT_CNT		4
+#define MIO_AIO_PORT_CNT		8
+typedef struct {
+
+    INT8U i8uIoConfig;                      // bitfield: 1=output, 0=input
+
+    INT8U i8uInputMode;                     // bitfield: 1=pwmIn, 0=pulseIn
+    INT8U i8uPullup;                     // bitfield: 1=pwmIn, 0=pulseIn
+
+    INT8U i8uOutputMode;                    // bitfield: 1=pwmOut, 0=digitalOut(pulseOut)
+    INT16U i16uPwmFrequency[MIO_PWM_TMR_CNT];             // pwm output frequency (Hz)
+    INT16U i16uPulseLength[MIO_DIO_PORT_CNT];              // pulse length (ms)
+    INT8U i8uPulseRetriggerMode;            // bitfield: 1=retrigger after OutputState Toggle, 0=no retrigger
+
+} SMioDIOConfigData;
+
+// Requests for Multi IO modules: Config
+typedef struct      // IOP_TYP1_CMD_CFG
+{
+    UIoProtocolHeader uHeader;
+
+	SMioDIOConfigData sData;
+
+    INT8U i8uCrc;
+} SMioDIOConfig;
+
+typedef struct {
+    INT8U i8uDirection;               // bitfield: 1=output (Fixed Output), 0=input (InputThreshold)
+
+	INT16U i16uVoltage[MIO_AIO_PORT_CNT];           // Input Threshold(dir=0) or Fixed Output(direction=1)
+
+} SMioAIOConfigData;
+
+typedef struct      // IOP_TYP1_CMD_DATA4
+{
+    UIoProtocolHeader uHeader;
+
+	SMioAIOConfigData sData;
+
+    INT8U i8uCrc;
+} SMioAIOConfig;
+
+//-----------------------------------------------------------------------------
+// Request for Multi IO modules:
+
+typedef struct {
+    INT8U i8uCalibrationMode;   //bitfield: mode
+    INT8U i8uChannels;          //channels to calibrate
+
+} SMioCalibrationRequestData;
+typedef struct      // IOP_TYP5_CMD_DATA6
+{
+    UIoProtocolHeader uHeader;
+
+	SMioCalibrationRequestData sData;
+
+    INT8U  i8uCrc;
+} SMioCalibrationRequest;
+
+typedef struct {
+	INT8U i8uOutputValue;			//bitfield: 1=high, 0=low (when IoMode==1)
+	INT16U i16uDutycycle[MIO_DIO_PORT_CNT];		//dutycycle: [0-1000]
+} SMioDigitalRequestData;
+
+typedef struct      // IOP_TYP1_CMD_DATA
+{
+    UIoProtocolHeader uHeader;
+
+	SMioDigitalRequestData sData;
+
+    INT8U  i8uCrc;
+} SMioDigitalRequest;
+
+typedef struct {
+    INT8U i8uChannels;              // analog channels to change    - 1 byte
+    INT16U i16uOutputVoltage[MIO_AIO_PORT_CNT];    // Output Voltage (mV)          - 16 bytes
+} SMioAnalogRequestData;
+
+typedef struct      // IOP_TYP5_CMD_DATA2
+{
+    UIoProtocolHeader uHeader;
+
+	SMioAnalogRequestData sData;
+
+    INT8U  i8uCrc;
+} SMioAnalogRequest;
+
+typedef struct {
+	INT16U i16uChannels;	// bitfield counter channel
+} SMioCounterResetData;
+
+typedef struct      // IOP_TYP1_CMD_DATA3
+{
+    UIoProtocolHeader uHeader;
+
+	SMioCounterResetData sData;
+
+    INT8U  i8uCrc;
+} SMioCounterReset;
+
+
+//-----------------------------------------------------------------------------
+//TODO: Code Review: the  cycled request and response data are visible to customer,
+//are those definitions clear to customer?
+typedef struct {
+    UIoProtocolHeader uHeader;
+
+    INT8U  i8uCrc;
+} SMioConfigResponse;
+
+typedef struct	{
+    INT8U i8uDigitalInputStatus;        //bitfield: 1=high, 0=low
+
+    INT16U i16uDcPlen[MIO_DIO_PORT_CNT];               // dutycycle: [0-1000] OR pulse-length
+    INT16U i16uFreqPcnt[MIO_DIO_PORT_CNT];             // pwm-frequency [Hz] OR pulse-count
+
+} SMioDigitalResponseData;
+
+// Response of Multi IO modules
+// Digital data response
+typedef struct      // IOP_TYP1_CMD_DATA
+{
+    UIoProtocolHeader uHeader;
+
+	SMioDigitalResponseData sData;
+
+    INT8U  i8uCrc;
+} SMioDigitalResponse;
+
+typedef struct {
+    INT8U i8uAnalogInputStatus;         // bitfield: 1=high, 0=low
+    INT16S i16sAnalogInputVoltage[MIO_AIO_PORT_CNT];        // analog input value
+} SMioAnalogResponseData;
+
+// Analog data response
+typedef struct      // IOP_TYP1_CMD_DATA2
+{
+    UIoProtocolHeader uHeader;
+
+	SMioAnalogResponseData sData;
+
+    INT8U  i8uCrc;
+} SMioAnalogResponse;
+
+#pragma pack(pop)
 #endif // IOPROTOCOL_H_INC

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ piControl-objs += revpi_core.o
 piControl-objs += revpi_gate.o
 piControl-objs += revpi_flat.o
 piControl-objs += pt100.o
+piControl-objs += revpi_mio.o
 
 ccflags-y := -O2
 ccflags-$(_ACPI_DEBUG) += -DACPI_DEBUG_OUTPUT

--- a/PiBridgeMaster.c
+++ b/PiBridgeMaster.c
@@ -47,6 +47,7 @@
 #include <ModGateRS485.h>
 #include <piDIOComm.h>
 #include <piAIOComm.h>
+#include <revpi_mio.h>
 #include "process_image.h"
 
 #define MAX_CONFIG_RETRIES 3		// max. retries for configuring a IO module
@@ -505,6 +506,13 @@ int PiBridgeMaster_Run(void)
 							RevPiDevice_getDev(i)->i8uActive = 0;
 						}
 						break;
+					case KUNBUS_FW_DESCR_TYP_PI_MIO:
+						ret = revpi_mio_init(i);
+						if(ret) {
+							pr_err("mio init failed in status-Continue(ret:%d)\n", ret);
+							RevPiDevice_getDev(i)->i8uActive = 0;
+						}
+						break;
 					}
 				}
 			}
@@ -611,6 +619,13 @@ int PiBridgeMaster_Run(void)
 									pr_err("piAIOComm_Init(%d) failed, error %d\n",
 										RevPiDevice_getDev(i)->i8uAddress, ret);
 								}
+								RevPiDevice_getDev(i)->i8uActive = 0;
+							}
+							break;
+						case KUNBUS_FW_DESCR_TYP_PI_MIO:
+							ret = revpi_mio_init(i);
+							if(ret) {
+								pr_err("mio init failed in status-EndConfig(ret:%d)\n", ret);
 								RevPiDevice_getDev(i)->i8uActive = 0;
 							}
 							break;

--- a/RevPiDevice.c
+++ b/RevPiDevice.c
@@ -44,6 +44,7 @@
 #include "revpi_core.h"
 #include <piDIOComm.h>
 #include <piAIOComm.h>
+#include <revpi_mio.h>
 
 static SDeviceConfig RevPiDevices_s;
 
@@ -128,6 +129,25 @@ void RevPiDevice_finish(void)
 	piIoComm_finish();
 }
 
+void revpi_dev_update_state(INT8U i8uDevice, INT32U r, int *retval)
+{
+	if (r) {
+		if (RevPiDevice_getDev(i8uDevice)->i16uErrorCnt < 255) {
+			RevPiDevice_getDev(i8uDevice)->i16uErrorCnt++;
+		}
+		else
+			RevPiDevice_getDev(i8uDevice)->i8uModuleState = IOSTATE_OFFLINE;
+		*retval -= 1;	// tell calling function that an error occured
+		if (RevPiDevice_getDev(i8uDevice)->i16uErrorCnt > 1) {
+			// the first error is ignored
+			RevPiDevices_s.i16uErrorCnt += RevPiDevice_getDev(i8uDevice)->i16uErrorCnt;
+		}
+	} else {
+		RevPiDevice_getDev(i8uDevice)->i16uErrorCnt = 0;
+		RevPiDevice_getDev(i8uDevice)->i8uModuleState = IOSTATE_CYCLIC_IO;
+	}
+}
+
 //*************************************************************************************************
 //| Function: RevPiDevice_run
 //|
@@ -142,7 +162,7 @@ void RevPiDevice_finish(void)
 int RevPiDevice_run(void)
 {
 	INT8U i8uDevice = 0;
-	INT32U r;
+	INT32U r = 0;
 	int retval = 0;
 
 	RevPiDevices_s.i16uErrorCnt = 0;
@@ -154,40 +174,16 @@ int RevPiDevice_run(void)
 			case KUNBUS_FW_DESCR_TYP_PI_DI_16:
 			case KUNBUS_FW_DESCR_TYP_PI_DO_16:
 				r = piDIOComm_sendCyclicTelegram(i8uDevice);
-				if (r) {
-					if (RevPiDevice_getDev(i8uDevice)->i16uErrorCnt < 255) {
-						RevPiDevice_getDev(i8uDevice)->i16uErrorCnt++;
-					}
-					else
-						RevPiDevice_getDev(i8uDevice)->i8uModuleState = DIOSTATE_OFFLINE;
-					retval -= 1;	// tell calling function that an error occured
-					if (RevPiDevice_getDev(i8uDevice)->i16uErrorCnt > 1) {
-						// the first error is ignored
-						RevPiDevices_s.i16uErrorCnt += RevPiDevice_getDev(i8uDevice)->i16uErrorCnt;
-					}
-				} else {
-					RevPiDevice_getDev(i8uDevice)->i16uErrorCnt = 0;
-					RevPiDevice_getDev(i8uDevice)->i8uModuleState = DIOSTATE_CYCLIC_IO;
-				}
+				revpi_dev_update_state(i8uDevice, r, &retval);
 				break;
 
 			case KUNBUS_FW_DESCR_TYP_PI_AIO:
 				r = piAIOComm_sendCyclicTelegram(i8uDevice);
-				if (r) {
-					if (RevPiDevice_getDev(i8uDevice)->i16uErrorCnt < 255) {
-						RevPiDevice_getDev(i8uDevice)->i16uErrorCnt++;
-					}
-					else
-						RevPiDevice_getDev(i8uDevice)->i8uModuleState = AIOSTATE_OFFLINE;
-					retval -= 1;	// tell calling function that an error occured
-					if (RevPiDevice_getDev(i8uDevice)->i16uErrorCnt > 1) {
-						// the first error is ignored
-						RevPiDevices_s.i16uErrorCnt += RevPiDevice_getDev(i8uDevice)->i16uErrorCnt;
-					}
-				} else {
-					RevPiDevice_getDev(i8uDevice)->i16uErrorCnt = 0;
-					RevPiDevice_getDev(i8uDevice)->i8uModuleState = AIOSTATE_CYCLIC_IO;
-				}
+				revpi_dev_update_state(i8uDevice, r, &retval);
+				break;
+			case KUNBUS_FW_DESCR_TYP_PI_MIO:
+				r = revpi_mio_cycle(i8uDevice);
+				revpi_dev_update_state(i8uDevice, r, &retval);
 				break;
 
 			case KUNBUS_FW_DESCR_TYP_MG_CAN_OPEN:

--- a/RevPiDevice.h
+++ b/RevPiDevice.h
@@ -53,6 +53,7 @@ typedef struct _SDevice
     INT16U i16uErrorCnt;
     MODGATECOM_IDResp sId;
     INT8U i8uModuleState;
+	INT8U i8uPriv;	//used by the module privately
 } SDevice;
 
 

--- a/common_define.h
+++ b/common_define.h
@@ -122,6 +122,7 @@ typedef struct S_KUNBUS_REV_NUMBER {
 #define KUNBUS_FW_DESCR_TYP_PI_CON_CAN                            109
 #define KUNBUS_FW_DESCR_TYP_PI_CON_MBUS                           110
 #define KUNBUS_FW_DESCR_TYP_PI_CON_BT                             111
+#define KUNBUS_FW_DESCR_TYP_PI_MIO                                117
 
 #define KUNBUS_FW_DESCR_TYP_INTERN                                  0xffff
 #define KUNBUS_FW_DESCR_TYP_UNDEFINED                               0xffff

--- a/piConfig.c
+++ b/piConfig.c
@@ -46,6 +46,7 @@
 #include <piConfig.h>
 #include <piDIOComm.h>
 #include <piAIOComm.h>
+#include <revpi_mio.h>
 #include <revpi_compact.h>
 
 #define TOKEN_DEVICES       "Devices"
@@ -913,6 +914,7 @@ int piConfigParse(const char *filename, piDevices ** devs, piEntries ** ent, piC
 	// copy the config value into the module driver
 	piDIOComm_InitStart();
 	piAIOComm_InitStart();
+	revpi_mio_reset();
 
 	for (i = 0; i < (*devs)->i16uNumDevices; i++) {
 		pr_info_config("device %d typ %d has %d entries. Offsets: Base=%3d"
@@ -935,6 +937,10 @@ int piConfigParse(const char *filename, piDevices ** devs, piEntries ** ent, piC
 			break;
 		case KUNBUS_FW_DESCR_TYP_PI_COMPACT:
 			revpi_compact_config((*devs)->dev[i].i8uAddress, (*devs)->dev[i].i16uEntries,
+					&(*ent)->ent[(*devs)->dev[i].i16uFirstEntry]);
+			break;
+		case KUNBUS_FW_DESCR_TYP_PI_MIO:
+			revpi_mio_config((*devs)->dev[i].i8uAddress, (*devs)->dev[i].i16uEntries,
 					&(*ent)->ent[(*devs)->dev[i].i16uFirstEntry]);
 			break;
 		}

--- a/piControl.h
+++ b/piControl.h
@@ -110,6 +110,7 @@
 #define  KB_CONFIG_START                    _IO(KB_IOC_MAGIC, 25 )  // for download of configuration to Master Gateway: restart IO communication
 #define  KB_SET_OUTPUT_WATCHDOG             _IO(KB_IOC_MAGIC, 26 )  // activate a watchdog for this handle. If write is not called for a given period all outputs are set to 0
 #define  KB_SET_POS                         _IO(KB_IOC_MAGIC, 27 )  // set the f_pos, the unsigned int * is used to interpret the pos value
+#define  KB_AIO_CALIBRATE                   _IO(KB_IOC_MAGIC, 28 )
 
 #define  KB_WAIT_FOR_EVENT                  _IO(KB_IOC_MAGIC, 50 )  // wait for an event. This call is normally blocking
 #define  KB_EVENT_RESET                     1       // piControl was reset, reload configuration
@@ -175,6 +176,13 @@ typedef struct SDIOResetCounterStr
     uint8_t     i8uAddress;             // Address of module in current configuration
     uint16_t    i16uBitfield;           // bitfield, if bit n is 1, reset counter/encoder on input n
 } SDIOResetCounter;
+
+typedef struct SAIOCalibrateStr
+{
+    uint8_t     i8uAddress;        // Address of module in current configuration
+    uint8_t     i8uCalibrationMode;  //bitfield: mode
+    uint8_t     i8uChannels;         //channels to calibrate
+} SAIOCalibrate;
 
 #define CONFIG_DATA_SIZE 256
 

--- a/piIOComm.c
+++ b/piIOComm.c
@@ -723,3 +723,39 @@ INT32S piIoComm_fwuReset(int address)
 {
 	return fwuResetModule(address);
 }
+
+void revpi_io_build_header(UIoProtocolHeader *hdr,
+		unsigned char addr, unsigned char len, unsigned char cmd)
+{
+	hdr->sHeaderTyp1.bitAddress = addr;
+	hdr->sHeaderTyp1.bitIoHeaderType = 0;
+	hdr->sHeaderTyp1.bitReqResp = 0;
+	hdr->sHeaderTyp1.bitLength = len;
+	hdr->sHeaderTyp1.bitCommand = cmd;
+}
+
+
+
+int revpi_io_talk(void *sndbuf, int sndlen, void *rcvbuf, int rcvlen)
+{
+	int ret;
+
+	ret = piIoComm_send(sndbuf, sndlen);
+	if (ret) {
+		pr_err_ratelimited("send buf to pibridge failed(len:%d)\n", sndlen);
+		return -ECOMM;
+	}
+
+	if (!rcvbuf || rcvlen == 0) {
+		return 0;
+	}
+
+	ret = piIoComm_recv(rcvbuf, rcvlen);
+	if(ret != rcvlen) {
+		pr_err_ratelimited("recv len from pibridge error(got:%d, exp:%d)",
+								ret, rcvlen);
+		return -ECOMM;
+	}
+
+	return 0;
+}

--- a/piIOComm.h
+++ b/piIOComm.h
@@ -44,6 +44,15 @@
 
 #define REV_PI_TTY_DEVICE	"/dev/ttyAMA0"
 
+typedef enum
+{
+    /* physically not connected */
+    IOSTATE_OFFLINE   = 0x00,
+    /* cyclical data exchange is active */
+    IOSTATE_CYCLIC_IO = 0x01,
+} IoCommStatus;
+
+
 typedef enum _EGpioValue
 {
     enGpioValue_Low  = 0,
@@ -94,3 +103,8 @@ INT32S piIoComm_fwuFlashErase(int address);
 INT32S piIoComm_fwuFlashWrite(int address, INT32U flashAddr, char *data, INT32U length);
 INT32S piIoComm_fwuReset(int address);
 
+void revpi_io_build_header(UIoProtocolHeader *hdr,
+		unsigned char addr, unsigned char len, unsigned char cmd);
+
+
+int revpi_io_talk(void *sndbuf, int sndlen, void *rcvbuf, int rcvlen);

--- a/revpi_mio.c
+++ b/revpi_mio.c
@@ -1,0 +1,425 @@
+/*
+ * Copyright (C) 2020 KUNBUS GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (version 2) as
+ * published by the Free Software Foundation.
+ */
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/uaccess.h>
+#include <linux/fcntl.h>
+#include <linux/termios.h>
+#include <linux/syscalls.h>
+#include <asm/uaccess.h>
+#include <asm/segment.h>
+#include <linux/fs.h>
+#include <linux/kthread.h>
+#include <linux/gpio.h>
+#include <linux/crc8.h>
+
+#include <project.h>
+#include <common_define.h>
+
+#include "revpi_common.h"
+#include "revpi_core.h"
+#include "revpi_mio.h"
+
+/* configurations of MIO modules */
+static struct mio_config mio_conf_list[REVPI_MIO_MAX];
+
+/* the counter of the MIO module */
+static int mio_conf_cnt;
+
+/* store the sent analog request.
+   the field i8uChannels of struct SMioAnalogRequestData takes no function here,
+   but it could be used for the debuging purpose */
+static  SMioAnalogRequestData mio_dio_request_last[REVPI_MIO_MAX];
+
+inline unsigned char revpi_crc8(void *buf, unsigned short len)
+{
+	return piIoComm_Crc8((INT8U *)buf, len);
+}
+
+
+int revpi_mio_cycle_dio(SDevice *dev, SMioDigitalRequestData *req_data,
+					SMioDigitalResponseData *resp_data)
+{
+	int ret;
+	SMioDigitalRequest req;
+	SMioDigitalResponse resp;
+	unsigned char crc_cal;
+
+	revpi_io_build_header(&req.uHeader, dev->i8uAddress, 
+			sizeof(SMioDigitalRequestData),
+			IOP_TYP1_CMD_DATA);
+
+	/*copy: from process image:output to request*/
+	rt_mutex_lock(&piDev_g.lockPI);
+	memcpy(&req.sData, req_data, sizeof(SMioDigitalRequestData));
+	rt_mutex_unlock(&piDev_g.lockPI);
+
+	req.i8uCrc = revpi_crc8(&req, sizeof(req) - 1);
+
+	ret = revpi_io_talk(&req, sizeof(req), &resp, sizeof(resp));
+	if(ret) {
+		pr_err_ratelimited("talk with mio for dio data error(addr:%d, ret:%d)\n",
+							dev->i8uAddress, ret);
+		return -EIO;
+	}
+	crc_cal = revpi_crc8(&resp, sizeof(resp) - 1);
+	if (resp.i8uCrc != crc_cal) {
+		pr_err_ratelimited("crc for dio data error(got:%d, expect:%d)\n",
+							resp.i8uCrc, crc_cal);
+		return -EBADMSG;
+	}
+
+	pr_info_once("headers of mio:dio data request: 0x%4x, response:0x%4x\n",
+		*(unsigned short*)&req.uHeader, *(unsigned short*)&resp.uHeader);
+
+	/*copy: from response to process image:input*/
+	rt_mutex_lock(&piDev_g.lockPI);
+	memcpy(resp_data, &resp.sData, sizeof(SMioDigitalResponseData));
+	rt_mutex_unlock(&piDev_g.lockPI);
+
+	return 0;
+}
+
+int revpi_mio_cycle_aio(SDevice *dev, SMioAnalogRequestData *req_data,
+			size_t ch_cnt, SMioAnalogResponseData *resp_data)
+{
+	int ret;
+
+	SMioAnalogRequest  req;
+	SMioAnalogResponse resp;
+	unsigned char crc_cal;
+
+	size_t compressed = (MIO_AIO_PORT_CNT - ch_cnt) * sizeof(INT16U);
+
+	revpi_io_build_header(&req.uHeader, dev->i8uAddress,
+		sizeof(SMioAnalogRequestData) - compressed, IOP_TYP1_CMD_DATA2);
+
+	/*copy: from process image:output to request*/
+	rt_mutex_lock(&piDev_g.lockPI);
+	memcpy(&req.sData, req_data, sizeof(SMioAnalogRequestData) - compressed);
+	rt_mutex_unlock(&piDev_g.lockPI);
+
+	req.i8uCrc = revpi_crc8(&req, sizeof(req) - 1 - compressed);
+	memcpy(&req.i8uCrc - compressed, &req.i8uCrc, 1); /*crc is adjoining data */
+
+	//pr_info_ratelimited("req:%*ph\n", sizeof(req) - compressed, &req);
+
+	ret = revpi_io_talk(&req, sizeof(req) - compressed, &resp, sizeof(resp));
+	if(ret) {
+		pr_err_ratelimited("talk with mio for aio data error(addr:%d, ret:%d)\n",
+							dev->i8uAddress, ret);
+		return -EIO;
+	}
+	//pr_info_ratelimited("resp:%*ph\n", sizeof(resp), &resp);
+
+	crc_cal = revpi_crc8(&resp, sizeof(resp) - 1);
+	if (resp.i8uCrc != crc_cal) {
+		pr_err_ratelimited("crc for aio data error(got:%d, expect:%d)\n",
+							resp.i8uCrc, crc_cal);
+		return -EBADMSG;
+	}
+
+	pr_info_once("headers of mio:aio data request: 0x%4x, response:0x%4x\n",
+		*(unsigned short*)&req.uHeader, *(unsigned short*)&resp.uHeader);
+	/*copy: from response to process image*/
+	rt_mutex_lock(&piDev_g.lockPI);
+	memcpy(resp_data, &resp.sData, sizeof(SMioAnalogResponseData));
+	rt_mutex_unlock(&piDev_g.lockPI);
+
+	return 0;
+}
+
+/*
+	compare to get the changed values of channels
+	input parameters:
+		a, b: data of two messages
+		count: count of channels
+		step: number of bytes for a channel
+	return:	bit map of changed channels
+*/
+unsigned long revpi_chnl_cmp(void *a, void *b, int count, int step)
+{
+	int i;
+	unsigned long ret;
+	unsigned char *pa, *pb;
+
+	pa = (unsigned char *)a;
+	pb = (unsigned char *)b;
+
+	for (i = 0; i < count; i++) {
+		if (memcmp(pa + i*step, pb + i*step, step)) {
+			set_bit(i, &ret);
+		}
+	}
+	return ret;
+}
+
+#define VALUE_MASK(v, h, l) ((v) & (GENMASK((h), (l))))
+#define VALUE_MASK_L(v, h) VALUE_MASK((v), (h), 0)
+#define VALUE_MASK_H(v, l) VALUE_MASK((v), (BITS_PER_LONG - 1), (l))
+
+/*
+	compress the channel, only data of changed channel will be taken
+	input parameters:
+		dst, dst: compress from src to dst
+		bitmap: compress according to
+		step: number of bytes for a channel
+	return: the count of channels has been taken.
+*/
+unsigned int revpi_chnl_compress(void *dst, void *src, unsigned long bitmap, int step)
+{
+	unsigned char *d, *s;
+	unsigned int i = 0;
+
+	s = (unsigned char *)src;
+	d = (unsigned char *)dst;
+
+	for(i = 0; i < 32 && VALUE_MASK_H(bitmap, i); i++) {
+		if (test_bit(i, &bitmap)) {
+			memcpy(d, s + i * step, step);
+			d += step;
+		}
+	}
+	return (d - (unsigned char *)dst) / step;
+}
+
+int revpi_mio_cycle(unsigned char devno)
+{
+	int ret;
+	SDevice *dev;
+	struct mio_process_image_out *proc_img_out;
+	struct mio_process_image_in *proc_img_in;
+	SMioAnalogRequestData *last;
+	SMioAnalogRequestData io_req_ex;
+	unsigned int ch_cnt = 0;
+
+	dev = RevPiDevice_getDev(devno);
+	last = &mio_dio_request_last[dev->i8uPriv];
+
+	proc_img_out = (struct mio_process_image_out *)(piDev_g.ai8uPI + dev->i16uOutputOffset);
+	proc_img_in = (struct mio_process_image_in *)(piDev_g.ai8uPI + dev->i16uInputOffset);
+
+	ret = revpi_mio_cycle_dio(dev, &proc_img_out->dio, &proc_img_in->dio);
+	if (ret) {
+		return ret;
+	}
+
+	/* for the AIO cycle */
+	io_req_ex.i8uChannels = revpi_chnl_cmp(&last->i16uOutputVoltage,
+		&proc_img_out->aio.i16uOutputVoltage, MIO_AIO_PORT_CNT, 2);
+	/* force to update from process image */
+	io_req_ex.i8uChannels |= proc_img_out->aio.i8uChannels;
+
+	if(io_req_ex.i8uChannels) {
+		memcpy(&last->i16uOutputVoltage,
+				&proc_img_out->aio.i16uOutputVoltage,
+				sizeof(unsigned short) * MIO_AIO_PORT_CNT);
+
+		ch_cnt = revpi_chnl_compress(&io_req_ex.i16uOutputVoltage,
+					&proc_img_out->aio.i16uOutputVoltage,
+					io_req_ex.i8uChannels, 2);
+
+		pr_info("copy bitmap, bitmap:0x%x, copied len:%d, data:%*ph\n",
+			io_req_ex.i8uChannels, ch_cnt, 17,&io_req_ex);
+	}
+	ret = revpi_mio_cycle_aio(dev, &io_req_ex, ch_cnt, &proc_img_in->aio);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+int revpi_mio_reset()
+{
+	mio_conf_cnt = 0;
+
+	return 0;
+}
+
+int revpi_mio_config(unsigned char addr, unsigned short ent_cnt, SEntryInfo *ent)
+{
+	int i, offset;
+	struct mio_config *conf;
+
+	if (mio_conf_cnt >= REVPI_MIO_MAX) {
+		pr_err("max. of MIOs(%d) reached(%d)\n", REVPI_MIO_MAX, mio_conf_cnt);
+		return -ERANGE;
+	}
+
+	conf = &mio_conf_list[mio_conf_cnt];
+
+
+	revpi_io_build_header(&conf->dio.uHeader, addr, 
+				sizeof(SMioDIOConfigData), IOP_TYP1_CMD_CFG);
+
+	revpi_io_build_header(&conf->aio_i.uHeader, addr,
+				sizeof(SMioAIOConfigData), IOP_TYP1_CMD_DATA4);
+	conf->aio_i.sData.i8uDirection = 0;
+
+	revpi_io_build_header(&conf->aio_o.uHeader, addr,
+				sizeof(SMioAIOConfigData), IOP_TYP1_CMD_DATA4);
+	conf->aio_o.sData.i8uDirection = 1;
+
+	pr_info("MIO configured(addr:%d, ent-cnt:%d, conf-no:%d, conf-base:%d, \
+dio hdr:0x%x,aio_i hdr:0x%x, aio_o hdr:0x%x)\n",
+		addr, ent_cnt, mio_conf_cnt, MIO_CONF_BASE,
+		*(unsigned short*)&mio_conf_list[mio_conf_cnt].dio.uHeader,
+		*(unsigned short*)&mio_conf_list[mio_conf_cnt].aio_i.uHeader,
+		*(unsigned short*)&mio_conf_list[mio_conf_cnt].aio_o.uHeader);
+
+	for (i = 0; i < 0; i++) {
+		offset = ent[i].i16uOffset;
+		pr_info("to deal with entity with offset:%d\n", offset);
+		switch (offset) {
+		case 0 ... MIO_CONF_BASE - 1:
+			/*nothing to do for input and output */
+			break;
+
+		case MIO_CONF_DIO_DIR:
+			conf->dio.sData.i8uIoConfig = ent[i].i32uDefault;
+			break;
+		case MIO_CONF_DIO_IMOD:
+			conf->dio.sData.i8uInputMode = ent[i].i32uDefault;
+			break;
+		case MIO_CONF_DIO_PUL:
+			conf->dio.sData.i8uPullup = ent[i].i32uDefault;
+			break;
+		case MIO_CONF_DIO_OMOD:
+			conf->dio.sData.i8uOutputMode = ent[i].i32uDefault;
+			break;
+		case MIO_CONF_DIO_FREQ ... MIO_CONF_DIO_PLEN - 1:
+			conf->dio.sData.i16uPwmFrequency[offset - MIO_CONF_DIO_FREQ]
+							= ent[i].i32uDefault;
+			break;
+		case MIO_CONF_DIO_PLEN ... MIO_CONF_DIO_TRIG - 1:
+			conf->dio.sData.i16uPulseLength[offset - MIO_CONF_DIO_FREQ]
+							= ent[i].i32uDefault;
+			break;
+		case MIO_CONF_DIO_TRIG:
+			conf->dio.sData.i8uPulseRetriggerMode = ent[i].i32uDefault;
+			break;
+		case MIO_CONF_AIO_IN ... MIO_CONF_AIO_OUT - 1:
+			/*0=input (InputThreshold)*/
+			conf->aio_i.sData.i8uDirection = 0;
+			conf->aio_i.sData.i16uVoltage[offset - MIO_CONF_AIO_IN]
+			       				= ent[i].i32uDefault;
+			break;
+		case MIO_CONF_AIO_OUT ... MIO_CONF_END - 1:
+			/*1=output(Fixed Output)*/
+			conf->aio_o.sData.i8uDirection = 1;
+			conf->aio_o.sData.i16uVoltage[offset - MIO_CONF_AIO_OUT] 
+							= ent[i].i32uDefault;
+			break;
+		default:
+			pr_warn("unknown config entry(offset:%d)\n", offset);
+			break;
+		}
+	}
+	conf->dio.i8uCrc = revpi_crc8(&conf->dio, sizeof(conf->dio) - 1);
+	conf->aio_i.i8uCrc = revpi_crc8(&conf->aio_i, sizeof(conf->aio_i) - 1);
+	conf->aio_o.i8uCrc = revpi_crc8(&conf->aio_o, sizeof(conf->aio_o) - 1);
+
+	mio_conf_cnt++;
+
+	return 0;
+}
+
+int revpi_mio_init(unsigned char devno)
+{
+	int i, ret;
+	struct mio_config *conf = NULL;
+	SMioConfigResponse resp;
+	unsigned char crc;
+	unsigned char addr;
+
+	addr = RevPiDevice_getDev(devno)->i8uAddress;
+
+	pr_info("MIO Initializing...(devno:%d, addr:%d)\n", devno, addr);
+
+	for (i = 0; i < mio_conf_cnt; i++) {
+		pr_info("search mio conf(index:%d, addr:%d)\n", i,
+			mio_conf_list[i].dio.uHeader.sHeaderTyp1.bitAddress);
+
+		if (mio_conf_list[i].dio.uHeader.sHeaderTyp1.bitAddress == addr) {
+
+			conf = &mio_conf_list[i];
+			RevPiDevice_getDev(devno)->i8uPriv = (unsigned char)i;
+
+			/*the address of dio and aio (in and out) should be the same*/
+			if ((conf->aio_i.uHeader.sHeaderTyp1.bitAddress != addr )
+				|| (conf->aio_o.uHeader.sHeaderTyp1.bitAddress != addr )) {
+
+				pr_warn("addr differ in mio conf(dio:%d, aio in:%d, aio out:%d)\n",
+					addr,
+					conf->aio_i.uHeader.sHeaderTyp1.bitAddress,
+					conf->aio_o.uHeader.sHeaderTyp1.bitAddress);
+			}
+			break;
+		}
+	}
+
+	if (!conf) {
+		pr_err("fail to find the mio module(devno:%d)\n", devno);
+		return -ENODATA;
+	}
+
+	/*dio*/
+	memset(&resp, 0, sizeof(resp));
+	ret = revpi_io_talk(&conf->dio, sizeof(conf->dio), &resp, sizeof(resp));
+	if(ret) {
+		pr_err("talk with mio for conf dio err(devno:%d, ret:%d)\n",
+							devno, ret);
+	}
+	pr_info("headers of mio:aio conf request: 0x%4x, response:0x%4x\n",
+					*(unsigned short*)&conf->dio.uHeader,
+					*(unsigned short*)&resp.uHeader);
+
+	crc = revpi_crc8(&resp, sizeof(resp) - 1);
+	if (resp.i8uCrc != crc) {
+		pr_err("crc for mio:dio conf err(got:%d, exp:%d)\n",
+						resp.i8uCrc, crc);
+	}
+
+	/*aio out*/
+	memset(&resp, 0, sizeof(resp));
+	ret = revpi_io_talk(&conf->aio_i, sizeof(conf->aio_i), &resp, sizeof(resp));
+	if(ret) {
+		pr_err("talk with mio for conf aio_i err(devno:%d, ret:%d)\n",
+							devno, ret);
+	}
+	pr_info("headers of mio:aio_i conf request: 0x%4x, response:0x%4x\n",
+					*(unsigned short*)&conf->aio_i.uHeader,
+					*(unsigned short*)&resp.uHeader);
+
+	crc = revpi_crc8(&resp, sizeof(resp) - 1);
+	if (resp.i8uCrc != crc) {
+		pr_err("crc for mio:aio_i conf err(got:%d, exp:%d)\n",
+						resp.i8uCrc, crc);
+	}
+
+	/*aio out*/
+	memset(&resp, 0, sizeof(resp));
+	ret = revpi_io_talk(&conf->aio_o, sizeof(conf->aio_o), &resp, sizeof(resp));
+	if(ret) {
+		pr_err("talk with mio for conf aio_o err(devno:%d, ret:%d)\n",
+								devno, ret);
+	}
+	pr_info("headers of mio:aio_o conf request: 0x%4x, response:0x%4x\n",
+					*(unsigned short*)&conf->aio_o.uHeader,
+					*(unsigned short*)&resp.uHeader);
+
+	crc = revpi_crc8(&resp, sizeof(resp) - 1);
+	if (resp.i8uCrc != crc) {
+		pr_err("crc for mio:aio_o conf err(got:%d, exp:%d)\n",
+						resp.i8uCrc, crc);
+	}
+
+	pr_info("MIO Initializing finished(devno:%d, addr:%d)\n", devno, addr);
+	return 0;
+}

--- a/revpi_mio.h
+++ b/revpi_mio.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 KUNBUS GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (version 2) as
+ * published by the Free Software Foundation.
+ */
+#ifndef _REVPI_MIO_H_
+#define _REVPI_MIO_H_
+
+#include <common_define.h>
+#include <IoProtocol.h>
+
+/************************************************/
+
+#define REVPI_MIO_MAX	10
+
+#define MIO_CONF_BASE	sizeof(SMioDigitalRequestData) + \
+			sizeof(SMioAnalogRequestData) + \
+			sizeof(SMioDigitalResponseData) + \
+			sizeof(SMioAnalogResponseData)
+
+#define MIO_CONF_DIO_DIR	MIO_CONF_BASE
+/*60*/
+
+#define MIO_CONF_DIO_IMOD	(MIO_CONF_DIO_DIR + 1)
+/*61*/
+
+#define MIO_CONF_DIO_PUL	(MIO_CONF_DIO_IMOD + 1)
+/*62*/
+
+#define MIO_CONF_DIO_OMOD	(MIO_CONF_DIO_PUL + 1)
+/*63*/
+
+#define MIO_CONF_DIO_FREQ	(MIO_CONF_DIO_OMOD + 1)
+/*64*/
+
+#define MIO_CONF_DIO_PLEN (MIO_CONF_DIO_FREQ + sizeof(INT16U) * MIO_PWM_TMR_CNT)
+/*70*/
+
+#define MIO_CONF_DIO_TRIG (MIO_CONF_DIO_PLEN + sizeof(INT16U) * MIO_DIO_PORT_CNT)
+/*78*/
+
+#define MIO_CONF_AIO_IN		(MIO_CONF_DIO_TRIG + 1)
+/*79*/
+
+#define MIO_CONF_AIO_OUT (MIO_CONF_AIO_IN + sizeof(INT16U) * MIO_AIO_PORT_CNT)
+/*95*/
+
+#define MIO_CONF_END	(MIO_CONF_AIO_OUT + sizeof(INT16U) * MIO_AIO_PORT_CNT)
+/*111*/
+
+
+/*
+because of the limitation of length field in UIoProtocolHeader, which has 5 bits,
+only maximum 31 bytes of data can be transmitted once, so the mio configurations
+is transmitted in 3 times.
+
+to make the struct mio_config can be directly used as the buffer for the
+request  IOP_TYP1_CMD_CFG(digital) and IOP_TYP1_CMD_DATA4(analog), complete
+structs for digital, analog input and analog output configurations are put here,
+despite of the repeated headers
+*/
+struct mio_config {
+	SMioDIOConfig dio;   /*digital configuration*/
+	SMioAIOConfig aio_i; /*analog configuration for input*/
+	SMioAIOConfig aio_o; /*analog configuration for output*/
+};
+
+struct mio_process_image_out {
+	SMioDigitalRequestData dio;
+	SMioAnalogRequestData aio;
+};
+
+struct mio_process_image_in {
+	SMioDigitalResponseData dio;
+	SMioAnalogResponseData aio;
+};
+
+
+int revpi_mio_init(unsigned char devno);
+int revpi_mio_config(unsigned char addr, unsigned short ent_cnt, SEntryInfo *ent);
+int revpi_mio_reset(void);
+int revpi_mio_cycle(unsigned char devno);
+#endif /* _REVPI_MIO_H_ */


### PR DESCRIPTION
Add the initial support for MultiIO module:
- MultiIO module initialization
- the analog output message is compressed
- the calibration is supported

Reviewed-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>
Signed-off-by: Zhi Han <z.han@kunbus.com>