### PR TITLE
piTest/debian: Create release 1.3.0-1~0flat1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+picontrol (1.3.0-1~0flat1) stable; urgency=medium
+
+  * Beta release for KUNBUS RevPi Flat.
+  * Add the revpi flat name to the list of known module names.
+
+ -- Philipp Rosenberger <p.rosenberger@kunbus.com>  Mon, 26 Oct 2020 12:43:41 +0100
+
 picontrol (1.2.1-1) stable; urgency=medium
 
   * Show names of the new Connect modules


### PR DESCRIPTION
This release supports the KUNBUS RevPi Flat.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>