### PR TITLE
piControl:flat: check for valid cofniguration data

### DIFF
--- a/revpi_flat.c
+++ b/revpi_flat.c
@@ -232,6 +232,11 @@ static void revpi_flat_adjust_config(void)
 	SDevice *dev;
 	int i;
 
+	/* Check if there are any valid parsing results at all. This might
+	   not be the case if an invalid config file was provided. */
+	if (piDev_g.devs == NULL)
+		return;
+
 	/* Add all virtual devices to list of known devices. The first device is
 	   the flat, so skip it. */
 	for (i = 1; i < piDev_g.devs->i16uNumDevices; i++) {


### PR DESCRIPTION
In revpi_flat_adjust_config() the list of devices that has been found by
parsing the configuration file is iterated.
However in case of an errorneous or not exising configuration file the
pointer that points to this list may be NULL.
Skip the device list iteration in this case to avoid a NULL pointer
dereference.

Reported-by: Simon Han <z.han@kunbus.de>
Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>