### PR TITLE
piTest: add support for Multi IO

### DIFF
--- a/piTest/piTest.c
+++ b/piTest/piTest.c
@@ -147,6 +147,8 @@ char *getModuleName(uint16_t moduletype)
 		return "RevPi CON M-Bus";
 	case 111:
 		return "RevPi CON BT";
+	case 118:
+		return "RevPi MIO";
 	case 135:
 		return "RevPi Flat";
 


### PR DESCRIPTION
the moduletype 118 has been used for the Multi IO in piControl,
piTest just follows that.

Signed-off-by: Zhi Han <z.han@kunbus.com>