### PR TITLE
Make CROSS_COMPILE make argument environment configurable instead of hardcoded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CROSS_COMPILE += arm-linux-gnueabihf-
 .PHONY: compiletime.h
 
 all: compiletime.h
-	$(MAKE) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) -C $(KDIR) M=$(PWD)  modules
+	$(MAKE) ARCH=arm CROSS_COMPILE="$(CROSS_COMPILE)" -C $(KDIR) M=$(PWD)  modules
 
 compiletime.h:
 	echo "#define COMPILETIME \""`date`"\"" > compiletime.h

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,12 @@ EXTRA_CFLAGS = -I$(src)/
 
 EXTRA_CFLAGS += -D__KUNBUSPI_KERNEL__
 
+CROSS_COMPILE += arm-linux-gnueabihf-
 
 .PHONY: compiletime.h
 
 all: compiletime.h
-	$(MAKE) ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- -C $(KDIR) M=$(PWD)  modules
+	$(MAKE) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) -C $(KDIR) M=$(PWD)  modules
 
 compiletime.h:
 	echo "#define COMPILETIME \""`date`"\"" > compiletime.h


### PR DESCRIPTION
I compile the kernel using a different compiler, with which I want to be able to compile piControl.
Changed the Makefile in such a way that I am able to influence the used compiler(toolchain).