### PR TITLE
piControl: Dont use wrong offset for default values

### DIFF
--- a/PiBridgeMaster.c
+++ b/PiBridgeMaster.c
@@ -229,22 +229,23 @@ void PiBridgeMaster_setDefaults(void)
 					piDev_g.ent->ent[i].i8uBitPos, piDev_g.ent->ent[i].i32uDefault);
 
 			if (piDev_g.ent->ent[i].i16uBitLength == 1) {
-				INT8U i8uValue, i8uMask, addr, bit;
+				INT8U i8uValue, i8uMask, bit;
+				unsigned int offset;
 
-				addr = piDev_g.ent->ent[i].i16uOffset;
+				offset = piDev_g.ent->ent[i].i16uOffset;
 				bit = piDev_g.ent->ent[i].i8uBitPos;
 
-				addr += bit / 8;
+				offset += bit / 8;
 				bit %= 8;
 
-				i8uValue = piDev_g.ai8uPIDefault[addr];
+				i8uValue = piDev_g.ai8uPIDefault[offset];
 
 				i8uMask = (1 << bit);
 				if (piDev_g.ent->ent[i].i32uDefault != 0)
 					i8uValue |= i8uMask;
 				else
 					i8uValue &= ~i8uMask;
-				piDev_g.ai8uPIDefault[addr] = i8uValue;
+				piDev_g.ai8uPIDefault[offset] = i8uValue;
 			} else if (piDev_g.ent->ent[i].i16uBitLength == 8) {
 				piDev_g.ai8uPIDefault[piDev_g.ent->ent[i].i16uOffset] =
 				    (INT8U) piDev_g.ent->ent[i].i32uDefault;


### PR DESCRIPTION
In PiBridgeMaster_setDefaults() dont use a INT8U variable to calculate the
offset of a bit within the shared memory segment (aka "process image").
This distorts all values which are greater than 255.
Instead use an unsigned int to provide the max possible offset within the
memory segment.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>