### PR TITLE
piControl: RevPi Gate communication with RT priority (REVPI-1740)

### DIFF
--- a/revpi_gate.c
+++ b/revpi_gate.c
@@ -175,6 +175,7 @@ static struct sk_buff *revpi_gate_create_packet(
 	skb_reset_network_header(skb);
 	tl = (MODGATECOM_TransportLayer *)skb_put(skb, sizeof(*tl));
 	skb->dev = dev;
+	skb->priority = TC_PRIO_REALTIME;
 	skb->protocol = htons(ETH_P_KUNBUSGW);
 
 	if (dev_hard_header(skb, dev, ETH_P_KUNBUSGW,


### PR DESCRIPTION
This reverts commit 66eb9fd3a11d.

Depends on https://github.com/RevolutionPi/linux/pull/49.