### PR TITLE
piControl:flat: handle missing config settings

### DIFF
--- a/revpi_compact.c
+++ b/revpi_compact.c
@@ -727,7 +727,8 @@ int revpi_compact_reset()
 	my_rt_mutex_lock(&piDev_g.lockPI);
 	revpi_compact_adjust_config();
 	memset(&image->usr, 0, sizeof(image->usr));
-	revpi_set_defaults(piDev_g.ai8uPI, piDev_g.ent);
+	if (piDev_g.ent)
+		revpi_set_defaults(piDev_g.ai8uPI, piDev_g.ent);
 	rt_mutex_unlock(&piDev_g.lockPI);
 
 	machine->config = revpi_compact_config_g;

--- a/revpi_flat.c
+++ b/revpi_flat.c
@@ -281,7 +281,8 @@ static void revpi_flat_set_defaults(void)
 {
 	my_rt_mutex_lock(&piDev_g.lockPI);
 	memset(piDev_g.ai8uPI, 0, sizeof(piDev_g.ai8uPI));
-	revpi_set_defaults(piDev_g.ai8uPI, piDev_g.ent);
+	if (piDev_g.ent)
+		revpi_set_defaults(piDev_g.ai8uPI, piDev_g.ent);
 	rt_mutex_unlock(&piDev_g.lockPI);
 }
 


### PR DESCRIPTION
In case that the file config.rsc could not be read (e.g. since it does not
exist), the piDev_g.ent pointer which points to the settings extracted
from this file, is NULL. Since function revpi_set_defaults() is not
prepared for this situation it causes a NULL pointer access in this case.
Fix this by checking piDev_g.ent for NULL before calling
revpi_set_defaults().

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>