### PR TITLE
Revert "[HACK] Compact: Disable MAX31913 status"

### DIFF
--- a/revpi_compact.c
+++ b/revpi_compact.c
@@ -15,6 +15,7 @@
 #include <linux/iio/iio.h>
 #include <linux/iio/machine.h>
 #include <linux/kthread.h>
+#include <linux/spi/max3191x.h>
 #include <linux/spi/spi.h>
 #include <linux/ktime.h>
 #include <linux/thermal.h>
@@ -150,11 +151,7 @@ static int revpi_compact_poll_io(void *data)
 		                                     machine->din->info,
 #endif
 		                                     val);
-		/*
-		 * FIXME: The status is unsupported since revpi-5.10 kernel.
-		 *        Remove din_status from picontrol too?
-		 */
-		image->drv.din_status = 0;
+		image->drv.din_status = max3191x_get_status(machine->din_dev);
 		image->drv.din = 0;
 		if (ret)
 			image->drv.din_status |= BIT(7);


### PR DESCRIPTION
This reverts commit ff433a175f2288a99936729e459f30e2df10b8c5.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>