### PR TITLE
piControl: Process gateway packets in task context (REVPI-1797)

### DIFF
--- a/RevPiDevice.c
+++ b/RevPiDevice.c
@@ -139,12 +139,6 @@ void RevPiDevice_init(void)
 	RevPiDevice_incDevCnt();
 }
 
-void RevPiDevice_finish(void)
-{
-	//pr_info("RevPiDevice_finish()\n");
-	piIoComm_finish();
-}
-
 void revpi_dev_update_state(INT8U i8uDevice, INT32U r, int *retval)
 {
 	if (r) {

--- a/RevPiDevice.h
+++ b/RevPiDevice.h
@@ -74,7 +74,6 @@ typedef struct _SDeviceConfig
 TBOOL RevPiDevice_writeNextConfiguration(INT8U i8uAddress_p, MODGATECOM_IDResp *pModgateId_p);
 
 void RevPiDevice_init(void);
-void RevPiDevice_finish(void);
 
 int RevPiDevice_run(void);
 TBOOL RevPiDevice_writeNextConfigurationRight(void);

--- a/piControlMain.c
+++ b/piControlMain.c
@@ -433,6 +433,10 @@ static void __exit piControlCleanup(void)
 
 	cdev_del(&piDev_g.cdev);
 
+	if ((piDev_g.machine_type == REVPI_CORE ||
+	     piDev_g.machine_type == REVPI_CONNECT) && isRunning())
+		PiBridgeMaster_Stop();
+
 	if (piDev_g.machine_type == REVPI_CORE) {
 		revpi_core_fini();
 	} else if (piDev_g.machine_type == REVPI_CONNECT) {

--- a/revpi_core.c
+++ b/revpi_core.c
@@ -231,8 +231,6 @@ static int piIoThread(void *data)
 		down(&piCore_g.ioSem);	// wait for timer
 	}
 
-	RevPiDevice_finish();
-
 	pr_info("piIO exit\n");
 	return 0;
 }


### PR DESCRIPTION
The receive handler for gateway packets, revpi_gate_rcv(), is called in
softirq context, hence cannot sleep.  However copying data to and from
the process image can only be performed from task context because
rt_mutexes may sleep.  Using a non-sleeping raw_spinlock_t for the
process image is not an option because user space access may sleep in
copy_from/to_user().  We could switch to the _nofault variant of
copy_from/to_user(), but that may break existing user space applications.

The best solution would be a reimplementation of the process image as a
lockless, RCU-protected scatterlist, but that's a complex undertaking.

As a bandaid, store received packets in a queue and defer processing
to a dedicated kthread running at RT priority.  This may slightly
increase latency for packet processing because the kthread needs to be
woken, on the other hand it allows reception and processing to happen
in parallel on different CPUs.

We haven't seen customer complaints caused by sleeping in softirq
context, most likely because the locks are rarely contended.
But Nicolai managed to trigger the issue on kernel 5.10:

```
  [ 2865.368410] WARNING: CPU: 1 PID: 1124 at kernel/rcu/tree_plugin.h:297 rcu_note_context_switch+0x110/0x794
  [ 2865.368565] CPU: 1 PID: 1124 Comm: irqpoll/piright Tainted: G         C O      5.10.74-rt54-v7+ #1
  [ 2865.368573] Hardware name: BCM2835
  [ 2865.368577] Backtrace:
  [ 2865.368581] [<80a524d4>] (dump_backtrace)
  [ 2865.368601] [<80a52840>] (show_stack)
  [ 2865.368612] [<80a56b08>] (dump_stack)
  [ 2865.368633] [<8011fe3c>] (__warn)
  [ 2865.368650] [<80a52e50>] (warn_slowpath_fmt)
  [ 2865.368667] [<801a9820>] (rcu_note_context_switch)
  [ 2865.368690] [<80a5c3b0>] (__schedule)
  [ 2865.368713] [<80a5ce7c>] (schedule)
  [ 2865.368732] [<80a5eb8c>] (__rt_mutex_slowlock)
  [ 2865.368754] [<80a5ecec>] (rt_mutex_slowlock_locked)
  [ 2865.368776] [<80a5ef70>] (rt_mutex_slowlock)
  [ 2865.368795] [<80a5f098>] (rt_mutex_lock)
  [ 2865.368853] [<7f1164e4>] (revpi_gate_rcv [piControl])
  [ 2865.368917] [<808e4d0c>] (__netif_receive_skb_one_core)
  [ 2865.368932] [<808e4dc4>] (__netif_receive_skb)
  [ 2865.368946] [<808e50b4>] (process_backlog)
  [ 2865.368966] [<808e6a5c>] (net_rx_action)
  [ 2865.368988] [<80101400>] (__do_softirq)
  [ 2865.369009] [<80128314>] (__local_bh_enable_ip)
  [ 2865.369029] [<808df2c8>] (netif_rx_ni)
  [ 2865.369051] [<7f13207c>] (ks8851_rx_skb_spi [ks8851_spi])
  [ 2865.369074] [<7f12d480>] (ks8851_irq [ks8851_common])
  [ 2865.369108] [<7f12d984>] (ks8851_irqpoll [ks8851_common])
  [ 2865.369132] [<80147784>] (kthread)
  [ 2865.369175] ---  [ end trace 0000000000000002 ]---
  [ 2866.369313] sched: RT throttling activated
  [ 2867.029511] piControl: piright: id request, resetting connection
  [ 2867.031441] piControl: piright: id request, resetting connection
  [ 2867.031516] piControl: piright: id request, resetting connection
  [ 2867.031542] piControl: piright: id request, resetting connection
  [ 2867.031564] piControl: piright: id request, resetting connection
  [ 2867.031585] piControl: piright: id request, resetting connection
  [ 2867.031607] piControl: piright: id request, resetting connection
  [ 2867.031629] piControl: piright: id request, resetting connection
  [ 2867.031650] piControl: piright: id request, resetting connection
  [ 2867.031670] piControl: piright: id request, resetting connection
  [ 2867.031691] piControl: piright: id request, resetting connection
  [ 2867.031777] piControl: piright: id request, resetting connection
  [ 2867.031981] piControl: piright: id request, resetting connection
  [ 2867.032177] piControl: piright: id request, resetting connection
  [ 2867.032361] piControl: piright: id request, resetting connection
  [ 2867.032547] piControl: piright: id request, resetting connection
  [ 2867.032746] piControl: piright: id request, resetting connection
  [ 2867.032929] piControl: piright: id request, resetting connection
  [ 2867.033119] piControl: piright: id request, resetting connection
  [ 2867.033313] piControl: piright: id request, resetting connection
  [ 2867.035256] piControl: piright: received id response ack 0x46, expected 0x59
  [ 2867.035263] piControl: piright: id response (module type 93 hw V0 sw V1.2 svn 13933 serial 3929 mac c8:3e:a7:00:5d:02)
  [ 2867.041138] piControl: piright: received id response while awaiting data packet
```