### PR TITLE
Feature/revpi 1833/cleanup

### DIFF
--- a/PiBridgeMaster.c
+++ b/PiBridgeMaster.c
@@ -849,7 +849,8 @@ int PiBridgeMaster_Run(void)
 			}
 		}
 
-		piCore_g.image.drv.i8uCPUFrequency = bcm2835_cpufreq_get_clock() / 10;
+		piCore_g.image.drv.i8uCPUFrequency =
+			bcm2835_cpufreq_get_clock(piCore_g.fw) / 10;
 
 		last_update = kbUT_getCurrentMs();
 	}

--- a/RevPiDevice.c
+++ b/RevPiDevice.c
@@ -139,12 +139,6 @@ void RevPiDevice_init(void)
 	RevPiDevice_incDevCnt();
 }
 
-void RevPiDevice_finish(void)
-{
-	//pr_info("RevPiDevice_finish()\n");
-	piIoComm_finish();
-}
-
 void revpi_dev_update_state(INT8U i8uDevice, INT32U r, int *retval)
 {
 	if (r) {

--- a/RevPiDevice.h
+++ b/RevPiDevice.h
@@ -74,7 +74,6 @@ typedef struct _SDeviceConfig
 TBOOL RevPiDevice_writeNextConfiguration(INT8U i8uAddress_p, MODGATECOM_IDResp *pModgateId_p);
 
 void RevPiDevice_init(void);
-void RevPiDevice_finish(void);
 
 int RevPiDevice_run(void);
 TBOOL RevPiDevice_writeNextConfigurationRight(void);

--- a/piAIOComm.c
+++ b/piAIOComm.c
@@ -37,7 +37,6 @@
 #include <linux/termios.h>
 #include <linux/syscalls.h>
 #include <asm/uaccess.h>
-#include <asm/segment.h>
 #include <linux/fs.h>
 #include <linux/kthread.h>
 #include <linux/gpio.h>

--- a/piConfig.c
+++ b/piConfig.c
@@ -38,7 +38,6 @@
 #include <linux/slab.h>		// included for KERN_INFO
 #include <linux/fs.h>
 #include <asm/uaccess.h>
-#include <asm/segment.h>
 
 #include "compat.h"
 #include "json.h"

--- a/piControlMain.c
+++ b/piControlMain.c
@@ -433,6 +433,10 @@ static void __exit piControlCleanup(void)
 
 	cdev_del(&piDev_g.cdev);
 
+	if ((piDev_g.machine_type == REVPI_CORE ||
+	     piDev_g.machine_type == REVPI_CONNECT) && isRunning())
+		PiBridgeMaster_Stop();
+
 	if (piDev_g.machine_type == REVPI_CORE) {
 		revpi_core_fini();
 	} else if (piDev_g.machine_type == REVPI_CONNECT) {

--- a/piControlMain.c
+++ b/piControlMain.c
@@ -81,6 +81,7 @@ MODULE_SOFTDEP("pre: bcm2835-thermal "	/* cpu temp in process image */
 	       "ks8851 "		/* core eth gateways */
 	       "spi-bcm2835 "		/* core spi0 eth gateways */
 	       "spi-bcm2835aux "	/* compact spi2 i/o */
+	       "gpio-max3191x "		/* compact din */
 	       "gpio-74x164 "		/* compact dout */
 	       "fixed "			/* compact ain/aout vref */
 	       "mux_gpio "		/* compact ain mux */

--- a/piControlMain.c
+++ b/piControlMain.c
@@ -752,12 +752,7 @@ static long piControlIoctl(struct file *file, unsigned int prg_nr, unsigned long
 			SDeviceInfo dev_info;
 			int i, found;
 
-			if (!access_ok(VERIFY_WRITE, (void __user *) usr_addr, sizeof(dev_info))) {
-				pr_err("invalid address provided by user\n");
-				return -EFAULT;
-			}
-
-			if (__copy_from_user(&dev_info, (const void __user *) usr_addr, sizeof(dev_info))) {
+			if (copy_from_user(&dev_info, (const void __user *) usr_addr, sizeof(dev_info))) {
 				pr_err("failed to copy dev info from user\n");
 				return -EFAULT;
 			}
@@ -789,7 +784,7 @@ static long piControlIoctl(struct file *file, unsigned int prg_nr, unsigned long
 				dev_info.i16uConfigOffset = RevPiDevice_getDev(i)->i16uConfigOffset;
 				dev_info.i8uModuleState = RevPiDevice_getDev(i)->i8uModuleState;
 
-				if (__copy_to_user((void * __user) usr_addr, &dev_info, sizeof(dev_info))) {
+				if (copy_to_user((void * __user) usr_addr, &dev_info, sizeof(dev_info))) {
 					pr_err("failed to copy dev info to user\n");
 					return -EFAULT;
 				}
@@ -871,13 +866,7 @@ static long piControlIoctl(struct file *file, unsigned int prg_nr, unsigned long
 			if (!isRunning())
 				return -EFAULT;
 
-			if (!access_ok(VERIFY_WRITE, (void __user *) usr_addr,
-				       sizeof(spi_val))) {
-				pr_err("invalid address provided by user\n");
-				return -EFAULT;
-			}
-
-			if (__copy_from_user(&spi_val, (const void __user *) usr_addr,
+			if (copy_from_user(&spi_val, (const void __user *) usr_addr,
 					     sizeof(spi_val))) {
 				pr_err("failed to copy spi value from user\n");
 				return -EFAULT;
@@ -897,7 +886,7 @@ static long piControlIoctl(struct file *file, unsigned int prg_nr, unsigned long
 					    ? 1 : 0;
 				}
 
-				if (__copy_to_user((void __user *) usr_addr, &spi_val,
+				if (copy_to_user((void __user *) usr_addr, &spi_val,
 						   sizeof(spi_val))) {
 					pr_err("failed to copy spi value to user\n");
 					return -EFAULT;

--- a/piDIOComm.c
+++ b/piDIOComm.c
@@ -37,7 +37,6 @@
 #include <linux/termios.h>
 #include <linux/syscalls.h>
 #include <asm/uaccess.h>
-#include <asm/segment.h>
 #include <linux/fs.h>
 #include <linux/kthread.h>
 #include <linux/gpio.h>

--- a/piFirmwareUpdate.c
+++ b/piFirmwareUpdate.c
@@ -39,7 +39,6 @@
 #include <linux/fs.h>
 #include <linux/delay.h>
 #include <asm/uaccess.h>
-#include <asm/segment.h>
 
 #include "compat.h"
 #include "revpi_common.h"

--- a/piIOComm.c
+++ b/piIOComm.c
@@ -37,7 +37,6 @@
 #include <linux/termios.h>
 #include <linux/syscalls.h>
 #include <asm/uaccess.h>
-#include <asm/segment.h>
 #include <linux/fs.h>
 #include <linux/kthread.h>
 #include <linux/gpio.h>

--- a/revpi_common.c
+++ b/revpi_common.c
@@ -228,7 +228,6 @@ uint32_t bcm2835_cpufreq_get_clock(void)
 int set_kthread_prios(const struct kthread_prio *ktprios)
 {
 	const struct kthread_prio *ktprio;
-	struct sched_param param = { };
 	struct task_struct *child;
 	int ret = 0;
 
@@ -240,17 +239,9 @@ int set_kthread_prios(const struct kthread_prio *ktprios)
 			if (!strncmp(child->comm, ktprio->comm,
 				     TASK_COMM_LEN)) {
 				found = true;
-				param.sched_priority = ktprio->prio;
-				ret = sched_setscheduler(child, SCHED_FIFO,
-							 &param);
-				if (ret) {
-					pr_err("cannot set priority of %s\n",
-					       ktprio->comm);
-					goto out;
-				} else {
-					pr_info("set priority of %s to %d\n",
-						ktprio->comm, ktprio->prio);
-				}
+				sched_set_fifo(child);
+				pr_info("set priority of %s to %d\n",
+						ktprio->comm, MAX_RT_PRIO / 2);
 				break;
 			}
 

--- a/revpi_common.c
+++ b/revpi_common.c
@@ -198,9 +198,8 @@ void revpi_release_firmware(struct rpi_firmware *fw)
 	rpi_firmware_put(fw);
 }
 
-static int bcm2835_cpufreq_clock_property(u32 tag, u32 id, u32 * val)
+static int bcm2835_cpufreq_clock_property(struct rpi_firmware * fw, u32 tag, u32 id, u32 * val)
 {
-	struct rpi_firmware *fw = rpi_firmware_get(NULL);
 	struct {
 		u32 id;
 		u32 val;
@@ -218,12 +217,13 @@ static int bcm2835_cpufreq_clock_property(u32 tag, u32 id, u32 * val)
 	return 0;
 }
 
-uint32_t bcm2835_cpufreq_get_clock(void)
+uint32_t bcm2835_cpufreq_get_clock(struct rpi_firmware *fw)
 {
 	u32 rate;
 	int ret;
 
-	ret = bcm2835_cpufreq_clock_property(RPI_FIRMWARE_GET_CLOCK_RATE, VCMSG_ID_ARM_CLOCK, &rate);
+	ret = bcm2835_cpufreq_clock_property(fw, RPI_FIRMWARE_GET_CLOCK_RATE,
+					     VCMSG_ID_ARM_CLOCK, &rate);
 	if (ret) {
 		pr_err("Failed to get clock (%d)\n", ret);
 		return 0;

--- a/revpi_common.c
+++ b/revpi_common.c
@@ -198,7 +198,7 @@ void revpi_release_firmware(struct rpi_firmware *fw)
 	rpi_firmware_put(fw);
 }
 
-int bcm2835_cpufreq_clock_property(u32 tag, u32 id, u32 * val)
+static int bcm2835_cpufreq_clock_property(u32 tag, u32 id, u32 * val)
 {
 	struct rpi_firmware *fw = rpi_firmware_get(NULL);
 	struct {
@@ -208,7 +208,7 @@ int bcm2835_cpufreq_clock_property(u32 tag, u32 id, u32 * val)
 	int ret;
 
 	packet.id = id;
-	packet.val = *val;
+	packet.val = 0;
 	ret = rpi_firmware_property(fw, tag, &packet, sizeof(packet));
 	if (ret)
 		return ret;

--- a/revpi_common.c
+++ b/revpi_common.c
@@ -178,6 +178,26 @@ void revpi_power_led_red_run(void)
 	}
 }
 
+struct rpi_firmware *revpi_get_firmware(void)
+{
+	char *fwpath = "/soc/firmware";
+	struct rpi_firmware *fw = NULL;
+	struct device_node *node;
+
+	node = of_find_node_by_path(fwpath);
+	if (node) {
+		fw = rpi_firmware_get(node);
+		of_node_put(node);
+	}
+
+	return fw;
+}
+
+void revpi_release_firmware(struct rpi_firmware *fw)
+{
+	rpi_firmware_put(fw);
+}
+
 int bcm2835_cpufreq_clock_property(u32 tag, u32 id, u32 * val)
 {
 	struct rpi_firmware *fw = rpi_firmware_get(NULL);

--- a/revpi_common.h
+++ b/revpi_common.h
@@ -1,5 +1,6 @@
 #include <linux/sched.h>
 #include <linux/version.h>
+#include <soc/bcm2835/raspberrypi-firmware.h>
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 #include <linux/sched/task.h>
 #include <uapi/linux/sched/types.h>
@@ -16,6 +17,8 @@ enum revpi_power_led_mode {
 void revpi_led_trigger_event(u16 led_prev, u16 led);
 void revpi_power_led_red_set(enum revpi_power_led_mode mode);
 void revpi_power_led_red_run(void);
+struct rpi_firmware *revpi_get_firmware(void);
+void revpi_release_firmware(struct rpi_firmware *fw);
 
 void revpi_check_timeout(void);
 

--- a/revpi_common.h
+++ b/revpi_common.h
@@ -22,7 +22,6 @@ void revpi_release_firmware(struct rpi_firmware *fw);
 
 void revpi_check_timeout(void);
 
-int bcm2835_cpufreq_clock_property(u32 tag, u32 id, u32 * val);
 uint32_t bcm2835_cpufreq_get_clock(void);
 extern char *lock_file;
 extern int lock_line;

--- a/revpi_common.h
+++ b/revpi_common.h
@@ -22,7 +22,7 @@ void revpi_release_firmware(struct rpi_firmware *fw);
 
 void revpi_check_timeout(void);
 
-uint32_t bcm2835_cpufreq_get_clock(void);
+uint32_t bcm2835_cpufreq_get_clock(struct rpi_firmware *fw);
 extern char *lock_file;
 extern int lock_line;
 

--- a/revpi_compact.c
+++ b/revpi_compact.c
@@ -516,7 +516,6 @@ void revpi_compact_adjust_config(void)
 int revpi_compact_init(void)
 {
 	SRevPiCompact *machine;
-	struct sched_param param = { };
 	struct device *dev;
 	int ret;
 
@@ -630,12 +629,7 @@ int revpi_compact_init(void)
 		goto err_release_aout1;
 	}
 
-	param.sched_priority = IO_THREAD_PRIO;
-	ret = sched_setscheduler(machine->io_thread, SCHED_FIFO, &param);
-	if (ret) {
-		pr_err("cannot upgrade i/o thread priority\n");
-		goto err_stop_io_thread;
-	}
+	sched_set_fifo(machine->io_thread);
 
 	machine->ain_thread = kthread_create(&revpi_compact_poll_ain, machine,
 					     "piControl ain");
@@ -645,12 +639,7 @@ int revpi_compact_init(void)
 		goto err_stop_io_thread;
 	}
 
-	param.sched_priority = AIN_THREAD_PRIO;
-	ret = sched_setscheduler(machine->ain_thread, SCHED_FIFO, &param);
-	if (ret) {
-		pr_err("cannot upgrade ain thread priority\n");
-		goto err_stop_ain_thread;
-	}
+	sched_set_fifo(machine->ain_thread);
 
 	ret = set_kthread_prios(revpi_compact_kthread_prios);
 	if (ret)

--- a/revpi_compact.c
+++ b/revpi_compact.c
@@ -364,7 +364,7 @@ next_chan:
 	return 0;
 }
 
-static int match_name(struct device *dev, void *data)
+static int match_name(struct device *dev, const void *data)
 {
 	const char *name = data;
 

--- a/revpi_compact.c
+++ b/revpi_compact.c
@@ -41,11 +41,7 @@
 static const struct kthread_prio revpi_compact_kthread_prios[] = {
 	/* spi pump to I/O chips */
 	{ .comm = "spi2",		.prio = MAX_USER_RT_PRIO/2 + 10 },
-	/* softirq daemons handling hrtimers */
-	{ .comm = "ktimersoftd/0",	.prio = MAX_USER_RT_PRIO/2 + 10 },
-	{ .comm = "ktimersoftd/1",	.prio = MAX_USER_RT_PRIO/2 + 10 },
-	{ .comm = "ktimersoftd/2",	.prio = MAX_USER_RT_PRIO/2 + 10 },
-	{ .comm = "ktimersoftd/3",	.prio = MAX_USER_RT_PRIO/2 + 10 },
+        /* softirq daemons handling hrtimers */
 	{ }
 };
 

--- a/revpi_compact.c
+++ b/revpi_compact.c
@@ -122,7 +122,12 @@ static int revpi_compact_poll_io(void *data)
 	SRevPiCompactImage *image = &machine->image;
 	SRevPiCompactImage prev = { };
 	struct cycletimer ct;
-	int ret, i, val[8];
+	int ret, i;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0)
+	int val;
+#else
+	DECLARE_BITMAP(val, 8);
+#endif
 	bool err;
 #ifdef BENCH
 	ktime_t t[7];
@@ -154,8 +159,12 @@ static int revpi_compact_poll_io(void *data)
 		if (ret)
 			image->drv.din_status |= BIT(7);
 		else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0)
 			for (i = 0; i < ARRAY_SIZE(val); i++)
 				image->drv.din |= val[i] << i;
+#else
+			image->drv.din = (u8)val[0] & 0xff;
+#endif
 
 		MEASSURE(1);
 		/* poll dout fault pin */
@@ -169,8 +178,12 @@ static int revpi_compact_poll_io(void *data)
 		MEASSURE(3);
 		/* write dout on every cycle to feed watchdog */
 		/* FIXME: GPIO core should return non-void for set() */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0)
 		for (i = 0; i < ARRAY_SIZE(val); i++)
 			val[i] = image->usr.dout & BIT(i);
+#else
+		val[0] = image->usr.dout & 0xff;
+#endif
 		gpiod_set_array_value_cansleep(machine->dout->ndescs,
 		                               machine->dout->desc,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)

--- a/revpi_compact.c
+++ b/revpi_compact.c
@@ -144,7 +144,11 @@ static int revpi_compact_poll_io(void *data)
 		MEASSURE(0);
 		/* poll din */
 		ret = gpiod_get_array_value_cansleep(machine->din->ndescs,
-						     machine->din->desc, val);
+		                                     machine->din->desc,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
+		                                     machine->din->info,
+#endif
+		                                     val);
 		image->drv.din_status = max3191x_get_status(machine->din_dev);
 		image->drv.din = 0;
 		if (ret)
@@ -168,7 +172,11 @@ static int revpi_compact_poll_io(void *data)
 		for (i = 0; i < ARRAY_SIZE(val); i++)
 			val[i] = image->usr.dout & BIT(i);
 		gpiod_set_array_value_cansleep(machine->dout->ndescs,
-					       machine->dout->desc, val);
+		                               machine->dout->desc,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
+		                               machine->dout->info,
+#endif
+		                               val);
 
 		MEASSURE(4);
 		/* write aout channels only if changed by user */

--- a/revpi_compact.c
+++ b/revpi_compact.c
@@ -254,7 +254,7 @@ static int revpi_compact_poll_ain(void *data)
 	while (!kthread_should_stop()) {
 		unsigned long long tmp;
 
-		smp_read_barrier_depends();
+		smp_rmb();
 		if (machine->ain_should_reset) {
 			/* determine which channels are enabled */
 			pr_info_aio("AIn Reset: config %d %d %d %d %d %d %d %d\n",

--- a/revpi_compact.c
+++ b/revpi_compact.c
@@ -743,7 +743,8 @@ int revpi_compact_reset()
 	my_rt_mutex_lock(&piDev_g.lockPI);
 	revpi_compact_adjust_config();
 	memset(&image->usr, 0, sizeof(image->usr));
-	revpi_set_defaults(piDev_g.ai8uPI, piDev_g.ent);
+	if (piDev_g.ent)
+		revpi_set_defaults(piDev_g.ai8uPI, piDev_g.ent);
 	rt_mutex_unlock(&piDev_g.lockPI);
 
 	machine->config = revpi_compact_config_g;

--- a/revpi_compact.c
+++ b/revpi_compact.c
@@ -50,6 +50,7 @@ static const struct kthread_prio revpi_compact_kthread_prios[] = {
 };
 
 typedef struct _SRevPiCompact {
+	struct rpi_firmware *fw;
 	SRevPiCompactImage image;
 	SRevPiCompactConfig config;
 	struct task_struct *io_thread;
@@ -353,7 +354,8 @@ next_chan:
 				}
 			}
 
-			image->drv.i8uCPUFrequency = bcm2835_cpufreq_get_clock() / 10;
+			image->drv.i8uCPUFrequency =
+				bcm2835_cpufreq_get_clock(machine->fw) / 10;
 			rt_mutex_unlock(&piDev_g.lockPI);
 		}
 
@@ -545,6 +547,12 @@ int revpi_compact_init(void)
 		return -ENOMEM;
 
 	piDev_g.machine = machine;
+	machine->fw = revpi_get_firmware();
+	if (!machine->fw) {
+		pr_err("cannot acquire RPI firmware\n");
+		return -ENXIO;
+	}
+
 	machine->config = revpi_compact_config_g;
 	machine->ain_should_reset = true;
 	init_completion(&machine->ain_reset);
@@ -697,6 +705,7 @@ err_put_din:
 	gpiod_put_array(machine->din);
 err_remove_table:
 	gpiod_remove_lookup_table(&revpi_compact_gpios);
+	revpi_release_firmware(machine->fw);
 	piDev_g.machine = NULL;
 	return ret;
 }
@@ -723,6 +732,7 @@ void revpi_compact_fini(void)
 	gpiod_put_array(machine->dout);
 	gpiod_put_array(machine->din);
 	gpiod_remove_lookup_table(&revpi_compact_gpios);
+	revpi_release_firmware(machine->fw);
 	piDev_g.machine = NULL;
 }
 

--- a/revpi_core.c
+++ b/revpi_core.c
@@ -231,8 +231,6 @@ static int piIoThread(void *data)
 		down(&piCore_g.ioSem);	// wait for timer
 	}
 
-	RevPiDevice_finish();
-
 	pr_info("piIO exit\n");
 	return 0;
 }

--- a/revpi_core.c
+++ b/revpi_core.c
@@ -47,17 +47,6 @@ static const struct kthread_prio revpi_core_kthread_prios[] = {
 	{ }
 };
 
-static struct gpiod_lookup_table revpi_core_gpios = {
-	.dev_id = "piControl0",
-	.table  = { GPIO_LOOKUP_IDX("pinctrl-bcm2835", 42, "Sniff1A", 0, GPIO_ACTIVE_HIGH),	// 1 links
-		    GPIO_LOOKUP_IDX("pinctrl-bcm2835", 43, "Sniff1B", 0, GPIO_ACTIVE_HIGH),	// 1 rechts
-		    GPIO_LOOKUP_IDX("pinctrl-bcm2835", 28, "Sniff2A", 0, GPIO_ACTIVE_HIGH),	// 2 links
-		    GPIO_LOOKUP_IDX("pinctrl-bcm2835", 29, "Sniff2B", 0, GPIO_ACTIVE_HIGH),	// 2 rechts
-	},
-};
-
-// im Schaltplan heißen die Pins 1B und 2B, da sie links sind, müssten sie aber 1A und 1B heißen.
-// hier in der Software werden sie mit A benannt
 static struct gpiod_lookup_table revpi_connect_gpios = {
 	.dev_id = "piControl0",
 	.table  = { GPIO_LOOKUP_IDX("pinctrl-bcm2835", 43, "Sniff1A",	0, GPIO_ACTIVE_HIGH),	// 1 links
@@ -235,19 +224,149 @@ static int piIoThread(void *data)
 	return 0;
 }
 
-int revpi_core_init(void)
+static void deinit_sniff_gpios(void)
 {
-	int ret = 0;
+	/* reset GPIO direction */
+	piIoComm_writeSniff1A(enGpioValue_Low, enGpioMode_Input);
+	piIoComm_writeSniff2A(enGpioValue_Low, enGpioMode_Input);
+
+	if (piDev_g.machine_type == REVPI_CORE) {
+		piIoComm_writeSniff1B(enGpioValue_Low, enGpioMode_Input);
+		piIoComm_writeSniff2B(enGpioValue_Low, enGpioMode_Input);
+	}
+}
+
+static void deinit_connect_gpios(void)
+{
+	gpiod_put(piCore_g.gpio_wdtrigger);
+	gpiod_put(piCore_g.gpio_x2do);
+	gpiod_put(piCore_g.gpio_x2di);
+	gpiod_remove_lookup_table(&revpi_connect_gpios);
+}
+
+static void deinit_gpios(void)
+{
+	deinit_sniff_gpios();
+	if (piDev_g.machine_type == REVPI_CONNECT)
+		deinit_connect_gpios();
+}
+
+static int init_sniff_gpios(struct platform_device *pdev)
+{
+	struct gpio_descs *descs;
+
+	descs = devm_gpiod_get_array(&pdev->dev, "left-sniff", GPIOD_IN);
+	if (IS_ERR(descs)) {
+		dev_err(&pdev->dev, "Failed to get left sniff gpios\n");
+		return PTR_ERR(descs);
+	}
+
+	if (descs->ndescs != 2) {
+		dev_err(&pdev->dev, "Invalid number of left sniff gpios (%u)\n",
+			descs->ndescs);
+		return -ENXIO;
+	}
+	/*
+	 * Note: in the schematic for the connect these pins are named 1B
+	 * and 2B although since they are for the left side, they should
+	 * rather be named 1A and 1B. However here in software we name them
+	 * 1a and 2a for both connect and core.
+	 */
+	piCore_g.gpio_sniff1a = descs->desc[0];
+	piCore_g.gpio_sniff2a = descs->desc[1];
+
+	if (piDev_g.machine_type == REVPI_CORE) {
+		descs = devm_gpiod_get_array(&pdev->dev, "right-sniff", GPIOD_IN);
+		if (IS_ERR(descs)) {
+			dev_err(&pdev->dev, "Failed to get right sniff gpios\n");
+			return PTR_ERR(descs);
+		}
+
+		if (descs->ndescs != 2) {
+			dev_err(&pdev->dev, "Invalid number of right sniff gpios (%u)\n",
+				descs->ndescs);
+			return -ENXIO;
+		}
+		piCore_g.gpio_sniff1b = descs->desc[0];
+		piCore_g.gpio_sniff2b = descs->desc[1];
+	}
+
+	return 0;
+}
+
+static int init_connect_gpios(void)
+{
+	int ret;
+	// the connect has only a only one modular gateway port on the left
+	gpiod_add_lookup_table(&revpi_connect_gpios);
+
+	piCore_g.gpio_x2di = gpiod_get(piDev_g.dev, "X2_DI", GPIOD_IN);
+	if (IS_ERR(piCore_g.gpio_x2di)) {
+		pr_err("cannot acquire gpio x2 di\n");
+		ret = PTR_ERR(piCore_g.gpio_x2di);
+		goto err_remove_table;
+	}
+	piCore_g.gpio_x2do = gpiod_get(piDev_g.dev, "X2_DO", GPIOD_OUT_LOW);
+	if (IS_ERR(piCore_g.gpio_x2do)) {
+		pr_err("cannot acquire gpio x2 do\n");
+		ret = PTR_ERR(piCore_g.gpio_x2do);
+		goto err_free_x2di;
+	}
+	piCore_g.gpio_wdtrigger = gpiod_get(piDev_g.dev, "WDTrigger", GPIOD_OUT_LOW);
+	if (IS_ERR(piCore_g.gpio_wdtrigger)) {
+		pr_err("cannot acquire gpio watchdog trigger\n");
+		ret = PTR_ERR(piCore_g.gpio_wdtrigger);
+		goto err_free_x2do;
+	}
+
+	return 0;
+
+err_free_x2do:
+	gpiod_put(piCore_g.gpio_x2do);
+err_free_x2di:
+	gpiod_put(piCore_g.gpio_x2di);
+err_remove_table:
+	gpiod_remove_lookup_table(&revpi_connect_gpios);
+
+	return ret;
+}
+
+static int init_gpios(struct platform_device *pdev)
+{
+	int ret;
+
+	ret = init_sniff_gpios(pdev);
+	if (ret) {
+		dev_err(piDev_g.dev, "Failed to init sniff gpios: %i\n", ret);
+		return ret;
+	}
+
+	if (piDev_g.machine_type == REVPI_CONNECT) {
+		ret = init_connect_gpios();
+		if (ret) {
+			dev_err(piDev_g.dev, "Failed to init connect gpios: %i\n",
+				ret);
+			goto err_deinit_sniff_gpios;
+		}
+	}
+	return 0;
+
+err_deinit_sniff_gpios:
+	deinit_sniff_gpios();
+	return ret;
+}
+
+static int pibridge_probe(struct platform_device *pdev)
+{
+	int ret;
 
 	piCore_g.i8uLeftMGateIdx = REV_PI_DEV_UNDEF;
 	piCore_g.i8uRightMGateIdx = REV_PI_DEV_UNDEF;
 
-	if (piDev_g.machine_type == REVPI_CORE) {
-		// the Core has two modular gateway ports
-		gpiod_add_lookup_table(&revpi_core_gpios);
-	} else if (piDev_g.machine_type == REVPI_CONNECT) {
-		// the connect has only a only one modular gateway port on the left
-		gpiod_add_lookup_table(&revpi_connect_gpios);
+	ret = init_gpios(pdev);
+	if (ret) {
+		dev_err(piDev_g.dev, "Failed to init gpios: %i\n", ret);
+		return ret;
 	}
 
 	rt_mutex_init(&piCore_g.lockUserTel);
@@ -264,62 +383,14 @@ int revpi_core_init(void)
 	piCore_g.fw = revpi_get_firmware();
 	if (!piCore_g.fw) {
 		dev_err(piDev_g.dev, "Failed to get revpi firmware\n");
-		return -ENXIO;
-	}
-
-	piCore_g.gpio_sniff1a = gpiod_get(piDev_g.dev, "Sniff1A", GPIOD_IN);
-	if (IS_ERR(piCore_g.gpio_sniff1a)) {
-		pr_err("cannot acquire gpio sniff 1a\n");
-		ret = PTR_ERR(piCore_g.gpio_sniff1a);
-		goto err_remove_table;
-	}
-	piCore_g.gpio_sniff2a = gpiod_get(piDev_g.dev, "Sniff2A", GPIOD_IN);
-	if (IS_ERR(piCore_g.gpio_sniff2a)) {
-		pr_err("cannot acquire gpio sniff 2a\n");
-		ret = PTR_ERR(piCore_g.gpio_sniff2a);
-		goto err_gpiod_put;
-	}
-	if (piDev_g.machine_type == REVPI_CORE) {
-		piCore_g.gpio_sniff1b = gpiod_get(piDev_g.dev, "Sniff1B", GPIOD_IN);
-		if (IS_ERR(piCore_g.gpio_sniff1b)) {
-			pr_err("cannot acquire gpio sniff 1b\n");
-			ret = PTR_ERR(piCore_g.gpio_sniff1b);
-			goto err_gpiod_put;
-		}
-		piCore_g.gpio_sniff2b = gpiod_get(piDev_g.dev, "Sniff2B", GPIOD_IN);
-		if (IS_ERR(piCore_g.gpio_sniff2b)) {
-			pr_err("cannot acquire gpio sniff 2b\n");
-			ret = PTR_ERR(piCore_g.gpio_sniff2b);
-			goto err_gpiod_put;
-		}
-	}
-	if (piDev_g.machine_type == REVPI_CONNECT) {
-		piCore_g.gpio_x2di = gpiod_get(piDev_g.dev, "X2_DI", GPIOD_IN);
-		if (IS_ERR(piCore_g.gpio_x2di)) {
-			pr_err("cannot acquire gpio x2 di\n");
-			ret = PTR_ERR(piCore_g.gpio_x2di);
-			goto err_gpiod_put;
-		}
-		piCore_g.gpio_x2do = gpiod_get(piDev_g.dev, "X2_DO", GPIOD_OUT_LOW);
-		if (IS_ERR(piCore_g.gpio_x2do)) {
-			pr_err("cannot acquire gpio x2 do\n");
-			ret = PTR_ERR(piCore_g.gpio_x2do);
-			goto err_gpiod_put;
-		}
-		piCore_g.gpio_wdtrigger = gpiod_get(piDev_g.dev, "WDTrigger", GPIOD_OUT_LOW);
-		if (IS_ERR(piCore_g.gpio_wdtrigger)) {
-			pr_err("cannot acquire gpio watchdog trigger\n");
-			ret = PTR_ERR(piCore_g.gpio_wdtrigger);
-			goto err_gpiod_put;
-		}
+		goto err_deinit_gpios;
 	}
 
 	if (piIoComm_init()) {
 		pr_err("open serial port failed\n");
 		ret = -EFAULT;
-		goto err_gpiod_put;
+		goto err_release_fw;
 	}
-
 	/* run threads */
 	ret = set_kthread_prios(revpi_core_kthread_prios);
 	if (ret)
@@ -341,41 +412,21 @@ int revpi_core_init(void)
 	}
 	sched_set_fifo(piCore_g.pIoThread);
 
-	return ret;
+	return 0;
 
 err_stop_uart_thread:
 	kthread_stop(piCore_g.pUartThread);
 err_close_serial:
 	piIoComm_finish();
-err_gpiod_put:
-	if (!IS_ERR_OR_NULL(piCore_g.gpio_sniff1a))
-		gpiod_put(piCore_g.gpio_sniff1a);
-	if (!IS_ERR_OR_NULL(piCore_g.gpio_sniff2a))
-		gpiod_put(piCore_g.gpio_sniff2a);
-	if (piDev_g.machine_type == REVPI_CORE) {
-		if (!IS_ERR_OR_NULL(piCore_g.gpio_sniff1b))
-			gpiod_put(piCore_g.gpio_sniff1b);
-		if (!IS_ERR_OR_NULL(piCore_g.gpio_sniff2b))
-			gpiod_put(piCore_g.gpio_sniff2b);
-	} else if (piDev_g.machine_type == REVPI_CONNECT) {
-		if (!IS_ERR_OR_NULL(piCore_g.gpio_x2di))
-			gpiod_put(piCore_g.gpio_x2di);
-		if (!IS_ERR_OR_NULL(piCore_g.gpio_x2do))
-			gpiod_put(piCore_g.gpio_x2do);
-		if (!IS_ERR_OR_NULL(piCore_g.gpio_wdtrigger))
-			gpiod_put(piCore_g.gpio_wdtrigger);
-	}
-err_remove_table:
-	if (piDev_g.machine_type == REVPI_CORE)
-		gpiod_remove_lookup_table(&revpi_core_gpios);
-	else if (piDev_g.machine_type == REVPI_CONNECT)
-		gpiod_remove_lookup_table(&revpi_connect_gpios);
+err_release_fw:
 	revpi_release_firmware(piCore_g.fw);
+err_deinit_gpios:
+	deinit_gpios();
 
 	return ret;
 }
 
-void revpi_core_fini(void)
+static int pibridge_remove(struct platform_device *pdev)
 {
 	/* tell UART thread to cancel the main loop */
 	send_sig(SIGTERM, piCore_g.pUartThread, 1);
@@ -383,27 +434,38 @@ void revpi_core_fini(void)
 	kthread_stop(piCore_g.pIoThread);
 	kthread_stop(piCore_g.pUartThread);
 	piIoComm_finish();
-
-	/* reset GPIO direction */
-	piIoComm_writeSniff1A(enGpioValue_Low, enGpioMode_Input);
-	gpiod_put(piCore_g.gpio_sniff1a);
-	piIoComm_writeSniff2A(enGpioValue_Low, enGpioMode_Input);
-	gpiod_put(piCore_g.gpio_sniff2a);
-	if (piDev_g.machine_type == REVPI_CORE) {
-		piIoComm_writeSniff1B(enGpioValue_Low, enGpioMode_Input);
-		gpiod_put(piCore_g.gpio_sniff1b);
-		piIoComm_writeSniff2B(enGpioValue_Low, enGpioMode_Input);
-		gpiod_put(piCore_g.gpio_sniff2b);
-	} else if (piDev_g.machine_type == REVPI_CONNECT) {
-		gpiod_put(piCore_g.gpio_x2di);
-		gpiod_put(piCore_g.gpio_x2do);
-		gpiod_put(piCore_g.gpio_wdtrigger);
-	}
-
-	if (piDev_g.machine_type == REVPI_CORE)
-		gpiod_remove_lookup_table(&revpi_core_gpios);
-	else if (piDev_g.machine_type == REVPI_CONNECT)
-		gpiod_remove_lookup_table(&revpi_connect_gpios);
-
 	revpi_release_firmware(piCore_g.fw);
+	deinit_gpios();
+
+	return 0;
+}
+
+static const struct of_device_id of_pibridge_match[] = {
+	{ .compatible = "kunbus,pibridge", },
+	{},
+};
+
+static struct platform_driver pibridge_driver = {
+	.probe		= pibridge_probe,
+	.remove 	= pibridge_remove,
+	.driver		= {
+		.name	= "pibridge",
+		.of_match_table = of_pibridge_match,
+	},
+};
+
+int revpi_core_init(void)
+{
+	int ret;
+
+	ret = platform_driver_register(&pibridge_driver);
+	if (ret)
+		pr_err("failed to register pibridge driver: %i\n", ret);
+
+	return ret;
+}
+
+void revpi_core_fini(void)
+{
+	platform_driver_unregister(&pibridge_driver);
 }

--- a/revpi_core.c
+++ b/revpi_core.c
@@ -239,7 +239,6 @@ static int piIoThread(void *data)
 
 int revpi_core_init(void)
 {
-	struct sched_param param;
 	int ret = 0;
 
 	piCore_g.i8uLeftMGateIdx = REV_PI_DEV_UNDEF;
@@ -328,12 +327,7 @@ int revpi_core_init(void)
 		ret = PTR_ERR(piCore_g.pUartThread);
 		goto err_close_serial;
 	}
-	param.sched_priority = RT_PRIO_UART;
-	sched_setscheduler(piCore_g.pUartThread, SCHED_FIFO, &param);
-	if (ret) {
-		pr_err("cannot set rt prio of uart thread\n");
-		goto err_stop_uart_thread;
-	}
+	sched_set_fifo(piCore_g.pUartThread);
 
 	piCore_g.pIoThread = kthread_run(&piIoThread, NULL, "piControl I/O");
 	if (IS_ERR(piCore_g.pIoThread)) {
@@ -341,17 +335,10 @@ int revpi_core_init(void)
 		ret = PTR_ERR(piCore_g.pIoThread);
 		goto err_stop_uart_thread;
 	}
-	param.sched_priority = RT_PRIO_BRIDGE;
-	ret = sched_setscheduler(piCore_g.pIoThread, SCHED_FIFO, &param);
-	if (ret) {
-		pr_err("cannot set rt prio of io thread\n");
-		goto err_stop_io_thread;
-	}
+	sched_set_fifo(piCore_g.pIoThread);
 
 	return ret;
 
-err_stop_io_thread:
-	kthread_stop(piCore_g.pIoThread);
 err_stop_uart_thread:
 	kthread_stop(piCore_g.pUartThread);
 err_close_serial:

--- a/revpi_core.c
+++ b/revpi_core.c
@@ -379,7 +379,9 @@ err_remove_table:
 
 void revpi_core_fini(void)
 {
-	// the IoThread cannot be stopped
+	/* tell UART thread to cancel the main loop */
+	send_sig(SIGTERM, piCore_g.pUartThread, 1);
+
 	kthread_stop(piCore_g.pIoThread);
 	kthread_stop(piCore_g.pUartThread);
 	piIoComm_finish();

--- a/revpi_core.c
+++ b/revpi_core.c
@@ -263,6 +263,12 @@ int revpi_core_init(void)
 	rt_mutex_init(&piCore_g.lockBridgeState);
 	sema_init(&piCore_g.ioSem, 0);
 
+	piCore_g.fw = revpi_get_firmware();
+	if (!piCore_g.fw) {
+		dev_err(piDev_g.dev, "Failed to get revpi firmware\n");
+		return -ENXIO;
+	}
+
 	piCore_g.gpio_sniff1a = gpiod_get(piDev_g.dev, "Sniff1A", GPIOD_IN);
 	if (IS_ERR(piCore_g.gpio_sniff1a)) {
 		pr_err("cannot acquire gpio sniff 1a\n");
@@ -366,6 +372,7 @@ err_remove_table:
 		gpiod_remove_lookup_table(&revpi_core_gpios);
 	else if (piDev_g.machine_type == REVPI_CONNECT)
 		gpiod_remove_lookup_table(&revpi_connect_gpios);
+	revpi_release_firmware(piCore_g.fw);
 
 	return ret;
 }
@@ -397,4 +404,6 @@ void revpi_core_fini(void)
 		gpiod_remove_lookup_table(&revpi_core_gpios);
 	else if (piDev_g.machine_type == REVPI_CONNECT)
 		gpiod_remove_lookup_table(&revpi_connect_gpios);
+
+	revpi_release_firmware(piCore_g.fw);
 }

--- a/revpi_core.h
+++ b/revpi_core.h
@@ -12,6 +12,7 @@
 #include <linux/wait.h>
 #include <linux/list.h>
 #include <linux/netdevice.h>
+#include <soc/bcm2835/raspberrypi-firmware.h>
 
 #include "IoProtocol.h"
 #include "ModGateComMain.h"
@@ -49,6 +50,7 @@ typedef struct _SRevPiCoreImage {
 
 typedef struct _SRevPiCore {
 	SRevPiCoreImage image;
+	struct rpi_firmware *fw;
 
 	// piGate stuff
 	INT8U i8uLeftMGateIdx;	// index of left GateModule in RevPiDevice_asDevice_m

--- a/revpi_flat.c
+++ b/revpi_flat.c
@@ -300,7 +300,6 @@ int revpi_flat_reset()
 int revpi_flat_init(void)
 {
 	struct revpi_flat *flat;
-	struct sched_param param = { };
 	struct device *dev;
 	int ret;
 
@@ -365,13 +364,7 @@ int revpi_flat_init(void)
 		ret = PTR_ERR(flat->dout_thread);
 		goto err_put_aout;
 	}
-
-	param.sched_priority = REVPI_FLAT_DOUT_THREAD_PRIO;
-	ret = sched_setscheduler(flat->dout_thread, SCHED_FIFO, &param);
-	if (ret) {
-		dev_err(piDev_g.dev, "cannot upgrade dout thread priority\n");
-		goto err_stop_dout_thread;
-	}
+	sched_set_fifo(flat->dout_thread);
 
 	flat->ain_thread = kthread_create(&revpi_flat_poll_ain, flat,
 					  "piControl ain");
@@ -380,13 +373,7 @@ int revpi_flat_init(void)
 		ret = PTR_ERR(flat->ain_thread);
 		goto err_stop_dout_thread;
 	}
-
-	param.sched_priority = REVPI_FLAT_AIN_THREAD_PRIO;
-	ret = sched_setscheduler(flat->ain_thread, SCHED_FIFO, &param);
-	if (ret) {
-		dev_err(piDev_g.dev, "cannot upgrade ain thread priority\n");
-		goto err_stop_ain_thread;
-	}
+	sched_set_fifo(flat->ain_thread);
 
 	ret = set_kthread_prios(revpi_flat_kthread_prios);
 	if (ret)

--- a/revpi_flat.c
+++ b/revpi_flat.c
@@ -222,7 +222,7 @@ static int revpi_flat_poll_ain(void *data)
 	return 0;
 }
 
-static int revpi_flat_match_iio_name(struct device *dev, void *data)
+static int revpi_flat_match_iio_name(struct device *dev, const void *data)
 {
 	return !strcmp(data, dev_to_iio_dev(dev)->name);
 }

--- a/revpi_flat.c
+++ b/revpi_flat.c
@@ -78,23 +78,6 @@ struct revpi_flat {
 	struct iio_channel aout;
 };
 
-static const struct kthread_prio revpi_flat_kthread_prios[] = {
-	/* softirq daemons handling hrtimers */
-	{ .comm = "ktimersoftd/0",
-	  .prio = MAX_USER_RT_PRIO/2 + 10
-	},
-	{ .comm = "ktimersoftd/1",
-	  .prio = MAX_USER_RT_PRIO/2 + 10
-	},
-	{ .comm = "ktimersoftd/2",
-	  .prio = MAX_USER_RT_PRIO/2 + 10
-	},
-	{ .comm = "ktimersoftd/3",
-	  .prio = MAX_USER_RT_PRIO/2 + 10
-	},
-	{ }
-};
-
 static int revpi_flat_poll_dout(void *data)
 {
 	struct revpi_flat *flat = (struct revpi_flat *) data;
@@ -375,10 +358,6 @@ int revpi_flat_init(void)
 	}
 	sched_set_fifo(flat->ain_thread);
 
-	ret = set_kthread_prios(revpi_flat_kthread_prios);
-	if (ret)
-		goto err_stop_ain_thread;
-
 	revpi_flat_reset();
 
 	wake_up_process(flat->dout_thread);
@@ -386,8 +365,6 @@ int revpi_flat_init(void)
 
 	return 0;
 
-err_stop_ain_thread:
-	kthread_stop(flat->ain_thread);
 err_stop_dout_thread:
 	kthread_stop(flat->dout_thread);
 err_put_aout:

--- a/revpi_flat.c
+++ b/revpi_flat.c
@@ -265,7 +265,8 @@ static void revpi_flat_set_defaults(void)
 {
 	my_rt_mutex_lock(&piDev_g.lockPI);
 	memset(piDev_g.ai8uPI, 0, sizeof(piDev_g.ai8uPI));
-	revpi_set_defaults(piDev_g.ai8uPI, piDev_g.ent);
+	if (piDev_g.ent)
+		revpi_set_defaults(piDev_g.ai8uPI, piDev_g.ent);
 	rt_mutex_unlock(&piDev_g.lockPI);
 }
 

--- a/revpi_mio.c
+++ b/revpi_mio.c
@@ -12,7 +12,6 @@
 #include <linux/termios.h>
 #include <linux/syscalls.h>
 #include <asm/uaccess.h>
-#include <asm/segment.h>
 #include <linux/fs.h>
 #include <linux/kthread.h>
 #include <linux/gpio.h>


### PR DESCRIPTION
- remove fc3aea683927df3eb531acdde56eb6a98eddb484 ("Revert "[HACK] Compact: Disable MAX31913 status"")
- remove ff433a175f2288a99936729e459f30e2df10b8c5 ("[HACK] Compact: Disable MAX31913 status")
- remove 66eb9fd3a11d7cd4ae25821ea0f547a662d256a1 ("Gate: Set TC_PRIO_REALTIME only on kernel < 4.20")
- remove 88b61ddb2a2510cb399e6275ab0137c5ad3b7f6a ("fixup! Gate: Set TC_PRIO_REALTIME only on kernel < 4.20")
- remove 3e69a79628e91526dd80096dcf962e60fb21c22c ("[HACK] the access_ok macro has changed with 5.0.0")
- move c47048399e9c31bcfeb1b264e5ad4546a5cedc6f ("piControl: use correct function to exchange data with userspace")
- add 35a76e0e95839de2f2a9b380f02a114680de631d "(HEAD -> feature/REVPI-1833/cleanup, origin/feature/REVPI-1833/cleanup) piControl: compact: Replace smp_read_barrier_depends() with smp_rmb()")