### PR TITLE
Use hardware interrupt timer instead in soft interrupt [REVPI-1936]

### DIFF
--- a/process_image.h
+++ b/process_image.h
@@ -36,7 +36,7 @@ static inline void cycletimer_sleep(struct cycletimer *ct)
 			missed_cycles - 1);
 
 	set_current_state(TASK_UNINTERRUPTIBLE);
-	hrtimer_restart(timer);
+	hrtimer_start_expires(timer, HRTIMER_MODE_ABS_HARD);
 	schedule();
 }
 
@@ -53,7 +53,7 @@ static inline void cycletimer_init_on_stack(struct cycletimer *ct, u32 cycletime
 {
 	struct hrtimer *timer = &ct->sleeper.timer;
 
-	hrtimer_init_on_stack(timer, CLOCK_MONOTONIC, HRTIMER_MODE_ABS);
+	hrtimer_init_on_stack(timer, CLOCK_MONOTONIC, HRTIMER_MODE_ABS_HARD);
 	timer->function = wake_up_sleeper;
 	ct->sleeper.task = current;
 	cycletimer_change(ct, cycletime);


### PR DESCRIPTION
The HRTIMER_MODE_ABS uses a softirq timer. This means the hrtimer will
wakup the softirqd and the softirqd will wakeup our thread. This causes
additional delays and jitter. We tried to combat this with increasing
the softirq priority.
The better solution is to wake our threads directly from hardware timer
interrupt. Thus using HRTIMER_MODE_ABS_HARD will do this for us.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>