### PR TITLE
flat: Fix bug introduced with 1462519 [REVPI-1935]

### DIFF
--- a/revpi_flat.c
+++ b/revpi_flat.c
@@ -209,7 +209,7 @@ static int revpi_flat_poll_ain(void *data)
 		freq = bcm2835_cpufreq_get_clock(flat->fw);
 
 		my_rt_mutex_lock(&piDev_g.lockPI);
-		if (piDev_g.thermal_zone != NULL && ret)
+		if ((piDev_g.thermal_zone != NULL) && !ret)
 			image->drv.cpu_temp = temperature / 1000;
 		image->drv.cpu_freq = freq / 10;
 		leds = image->usr.leds;


### PR DESCRIPTION
There was a bug inbtroduced with 1462519 ("flat: Shrink critical region
in the ain thread"). Check if ret is zero (no error) instead of
non-zero.

Also make the order in the comparrion explicit.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>