### PR TITLE
connect: Fix gpio assingment of x2do [REVPI-1949]

### DIFF
--- a/revpi_core.c
+++ b/revpi_core.c
@@ -282,7 +282,7 @@ static int init_connect_gpios(struct platform_device *pdev)
 		return PTR_ERR(piCore_g.gpio_x2di);
 	}
 
-	piCore_g.gpio_x2di = devm_gpiod_get_index(&pdev->dev, "connect", 1, GPIOD_OUT_LOW);
+	piCore_g.gpio_x2do = devm_gpiod_get_index(&pdev->dev, "connect", 1, GPIOD_OUT_LOW);
 	if (IS_ERR(piCore_g.gpio_x2do)) {
 		dev_err(&pdev->dev, "cannot acquire gpio x2 do\n");
 		return PTR_ERR(piCore_g.gpio_x2do);


### PR DESCRIPTION
The gpio of x2do (relay) was erroneously assigned to x2di. As a result
neigher x2di nor x2do worked on RevPi Connect.

Fiixes 7877a9921cd2edaa04784b4bc86478b2c287b154

Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>