### PR TITLE
Remove rt prio settings for ktimersoftd [REVPI-1964]

### DIFF
--- a/revpi_flat.c
+++ b/revpi_flat.c
@@ -79,23 +79,6 @@ struct revpi_flat {
 	struct iio_channel aout;
 };
 
-static const struct kthread_prio revpi_flat_kthread_prios[] = {
-	/* softirq daemons handling hrtimers */
-	{ .comm = "ktimersoftd/0",
-	  .prio = MAX_USER_RT_PRIO/2 + 10
-	},
-	{ .comm = "ktimersoftd/1",
-	  .prio = MAX_USER_RT_PRIO/2 + 10
-	},
-	{ .comm = "ktimersoftd/2",
-	  .prio = MAX_USER_RT_PRIO/2 + 10
-	},
-	{ .comm = "ktimersoftd/3",
-	  .prio = MAX_USER_RT_PRIO/2 + 10
-	},
-	{ }
-};
-
 static int revpi_flat_poll_dout(void *data)
 {
 	struct revpi_flat *flat = (struct revpi_flat *) data;
@@ -398,10 +381,6 @@ int revpi_flat_init(void)
 		dev_err(piDev_g.dev, "cannot upgrade ain thread priority\n");
 		goto err_stop_ain_thread;
 	}
-
-	ret = set_kthread_prios(revpi_flat_kthread_prios);
-	if (ret)
-		goto err_stop_ain_thread;
 
 	revpi_flat_reset();
 


### PR DESCRIPTION
ktimersoftd was removed with v5.0.19-rt11 patchset. Therefore manually setting
the rt prio of ktimersoftd results in an error on the RevPi Flat:

"piControl: cannot find kthread ktimersoftd/0"

Partialy revert of commit 370e4d9150ced81ed3dc61971a24a2f69744702d

Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>