### PR TITLE
piControl: compact: Avoid starving USB traffic [REVPI-2336]

### DIFF
--- a/revpi_common.h
+++ b/revpi_common.h
@@ -44,6 +44,9 @@ extern int lock_line;
 #define my_rt_mutex_lock(P)	rt_mutex_lock(P)
 #endif
 
+#define IRQ_THREAD "irq/*-"
+#define IRQ_THREAD_LEN (sizeof(IRQ_THREAD) - 1)
+
 struct kthread_prio {
 	const char comm[TASK_COMM_LEN];
 	int prio;

--- a/revpi_compact.c
+++ b/revpi_compact.c
@@ -41,7 +41,9 @@
 static const struct kthread_prio revpi_compact_kthread_prios[] = {
 	/* spi pump to I/O chips */
 	{ .comm = "spi2",		.prio = MAX_RT_PRIO/2 + 10 },
-        /* softirq daemons handling hrtimers */
+	/* usb traffic (softirq running on exit from IRQ thread) */
+	{ .comm = "irq/*-dwc_otg",	.prio = MAX_RT_PRIO/2 + 11 },
+	{ .comm = "irq/*-dwc_otg_",	.prio = MAX_RT_PRIO/2 + 11 },
 	{ }
 };
 


### PR DESCRIPTION
On kernel 5.10, piControl's high-priority tasks may starve USB traffic,
with keyboard and network URBs seemingly timing out.  The issue is
confined to dwc_otg and cannot be reproduced with dwc2. However, lack of
the FIQ optimization makes switching to dwc2 unattractive.

It turns out that raising the RT priority of dwc_otg's IRQ threads above
spi2 and piControl resolves the issue, at the expense of occasional
lost or premature cycles.  USB traffic is handled in softirq (tasklet)
context and it appears on kernel 5.10 that's done on exit from the
dwc_otg IRQ threads, whereas on 4.19 is was done by the ktimersoftd
threads.

The name of the dwc_otg IRQ threads contains the IRQ number, which is
variable.  In addition, there are two threads with identical name due
to TASK_COMM_LEN truncation.  Amend set_kthread_prios() to cope with
these two particularities.