### PR TITLE
piControl: compact: Lower priorities of kernel threads

### DIFF
--- a/revpi_compact.c
+++ b/revpi_compact.c
@@ -35,12 +35,12 @@
 #define REVPI_COMPACT_IO_CYCLE		( 250 * NSEC_PER_USEC)		// 250 usec
 #define REVPI_COMPACT_AIN_CYCLE		( 125 * NSEC_PER_MSEC)		// 125 msec
 
-#define IO_THREAD_PRIO	MAX_RT_PRIO/2 + 8
-#define AIN_THREAD_PRIO MAX_RT_PRIO/2 + 6
+#define IO_THREAD_PRIO	(MAX_RT_PRIO / 2)
+#define AIN_THREAD_PRIO (MAX_RT_PRIO / 2)
 
 static const struct kthread_prio revpi_compact_kthread_prios[] = {
 	/* spi pump to I/O chips */
-	{ .comm = "spi2",		.prio = MAX_RT_PRIO/2 + 10 },
+	{ .comm = "spi2",		.prio = (MAX_RT_PRIO / 2) },
         /* softirq daemons handling hrtimers */
 	{ }
 };


### PR DESCRIPTION
For compact the piControl module raises the priorities for the SPI (spi2)
thread to a realtime priority of 61 and the priorities of the ain and i/o
thread to 56 and 58 repectively.
As it turned this leads to massive perfomance issues on the USB ethernet
device. The reason seems to be that the USB worker threads (irq/X-dwc_otg)
with the lower priority of 50 are starving now from time to time.

To fix this make sure that the spi2, ain and i/o threads are not higher
prioritized than the USB worker threads.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>