### PR TITLE
piControl: support connect s compatible

### DIFF
--- a/piControlMain.c
+++ b/piControlMain.c
@@ -200,7 +200,8 @@ static int __init piControlInit(void)
 	if (of_machine_is_compatible("kunbus,revpi-compact")) {
 		piDev_g.machine_type = REVPI_COMPACT;
 		pr_info("RevPi Compact\n");
-	} else if (of_machine_is_compatible("kunbus,revpi-connect")) {
+	} else if (of_machine_is_compatible("kunbus,revpi-connect") ||
+		   of_machine_is_compatible("kunbus,revpi-connect-se")) {
 		piDev_g.machine_type = REVPI_CONNECT;
 		pr_info("RevPi Connect\n");
 	} else if (of_machine_is_compatible("kunbus,revpi-flat")) {


### PR DESCRIPTION
At module initialization the compatible string in the device tree is
checked to determine the device type. However there is no check for the
new compatible "kunbus,revpi-connect-se" yet, so that a Connect S is not
recognized as connect, but as a core (which is the default type).

Fix this by checking against the new compatible type.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>