### PR TITLE
add support for SE device (machine_type)

### DIFF
--- a/PiBridgeMaster.c
+++ b/PiBridgeMaster.c
@@ -66,7 +66,8 @@ static char *pcFWUdata;
 void PiBridgeMaster_Stop(void)
 {
 	my_rt_mutex_lock(&piCore_g.lockBridgeState);
-	if (piDev_g.machine_type != REVPI_CONNECT_SE)
+	if (piDev_g.machine_type != REVPI_CONNECT_SE &&
+	    piDev_g.machine_type != REVPI_CORE_SE)
 		revpi_gate_fini();
 	piCore_g.eBridgeState = piBridgeStop;
 	rt_mutex_unlock(&piCore_g.lockBridgeState);
@@ -76,7 +77,8 @@ void PiBridgeMaster_Continue(void)
 {
 	// this function can only be called, if the driver was running before
 	my_rt_mutex_lock(&piCore_g.lockBridgeState);
-	if (piDev_g.machine_type != REVPI_CONNECT_SE)
+	if (piDev_g.machine_type != REVPI_CONNECT_SE &&
+	    piDev_g.machine_type != REVPI_CORE_SE)
 		revpi_gate_init();
 	piCore_g.eBridgeState = piBridgeRun;
 	eRunStatus_s = enPiBridgeMasterStatus_Continue;	// make no initialization
@@ -652,7 +654,8 @@ int PiBridgeMaster_Run(void)
 				if (piCore_g.image.usr.i16uRS485ErrorLimit2 > 0
 				    && piCore_g.image.usr.i16uRS485ErrorLimit2 < RevPiDevice_getErrCnt()) {
 					pr_err("too many communication errors -> set BridgeState to stopped\n");
-					if (piDev_g.machine_type != REVPI_CONNECT_SE)
+					if (piDev_g.machine_type != REVPI_CONNECT_SE &&
+					    piDev_g.machine_type != REVPI_CORE_SE)
 						revpi_gate_fini();
 					piCore_g.eBridgeState = piBridgeStop;
 				} else if (piCore_g.image.usr.i16uRS485ErrorLimit1 > 0
@@ -704,7 +707,8 @@ int PiBridgeMaster_Run(void)
 				init_retry--;
 			} else {
 				pr_info("set BridgeState to running\n");
-				if (piDev_g.machine_type != REVPI_CONNECT_SE)
+				if (piDev_g.machine_type != REVPI_CONNECT_SE &&
+				    piDev_g.machine_type != REVPI_CORE_SE)
 					revpi_gate_init();
 				piCore_g.eBridgeState = piBridgeRun;
 			}

--- a/RevPiDevice.c
+++ b/RevPiDevice.c
@@ -119,6 +119,11 @@ void RevPiDevice_init(void)
 			RevPiDevice_getDev(RevPiDevice_getDevCnt())->i16uInputOffset = 0;
 			RevPiDevice_getDev(RevPiDevice_getDevCnt())->i16uOutputOffset = RevPiCore_ID_g.i16uFBS_InputLength;
 			break;
+		case REVPI_CORE_SE:
+			RevPiDevice_getDev(RevPiDevice_getDevCnt())->sId = RevPiCore_ID_g;
+			RevPiDevice_getDev(RevPiDevice_getDevCnt())->i16uInputOffset = 0;
+			RevPiDevice_getDev(RevPiDevice_getDevCnt())->i16uOutputOffset = RevPiCore_ID_g.i16uFBS_InputLength;
+			break;
 		case REVPI_COMPACT:
 			RevPiDevice_getDev(RevPiDevice_getDevCnt())->sId = RevPiCompact_ID_g;
 			RevPiDevice_getDev(RevPiDevice_getDevCnt())->i16uInputOffset = 0;

--- a/RevPiDevice.c
+++ b/RevPiDevice.c
@@ -129,6 +129,11 @@ void RevPiDevice_init(void)
 			RevPiDevice_getDev(RevPiDevice_getDevCnt())->i16uInputOffset = 0;
 			RevPiDevice_getDev(RevPiDevice_getDevCnt())->i16uOutputOffset = RevPiConnect_ID_g.i16uFBS_InputLength;
 			break;
+		case REVPI_CONNECT_SE:
+			RevPiDevice_getDev(RevPiDevice_getDevCnt())->sId = RevPiConnect_ID_g;
+			RevPiDevice_getDev(RevPiDevice_getDevCnt())->i16uInputOffset = 0;
+			RevPiDevice_getDev(RevPiDevice_getDevCnt())->i16uOutputOffset = RevPiConnect_ID_g.i16uFBS_InputLength;
+			break;
 		case REVPI_FLAT:
 			RevPiDevice_getDev(RevPiDevice_getDevCnt())->sId = RevPiFlat_ID_g;
 			RevPiDevice_getDev(RevPiDevice_getDevCnt())->i16uInputOffset = 0;

--- a/piControlMain.h
+++ b/piControlMain.h
@@ -59,6 +59,7 @@ enum revpi_machine {
 	REVPI_CONNECT = 3,
 	REVPI_FLAT = 4,
 	REVPI_CONNECT_SE = 5,
+	REVPI_CORE_SE = 6,
 };
 
 typedef struct spiControlDev {

--- a/piControlMain.h
+++ b/piControlMain.h
@@ -58,6 +58,7 @@ enum revpi_machine {
 	REVPI_COMPACT = 2,
 	REVPI_CONNECT = 3,
 	REVPI_FLAT = 4,
+	REVPI_CONNECT_SE = 5,
 };
 
 typedef struct spiControlDev {

--- a/piIOComm.c
+++ b/piIOComm.c
@@ -429,7 +429,8 @@ void piIoComm_writeSniff1A(EGpioValue eVal_p, EGpioMode eMode_p)
 
 void piIoComm_writeSniff1B(EGpioValue eVal_p, EGpioMode eMode_p)
 {
-	if (piDev_g.machine_type == REVPI_CORE) {
+	if (piDev_g.machine_type == REVPI_CORE ||
+	    piDev_g.machine_type == REVPI_CORE_SE) {
 		piIoComm_writeSniff(piCore_g.gpio_sniff1b, eVal_p, eMode_p);
 #ifdef DEBUG_GPIO
 		pr_info("sniff1B: mode %d value %d\n", (int)eMode_p, (int)eVal_p);
@@ -447,7 +448,8 @@ void piIoComm_writeSniff2A(EGpioValue eVal_p, EGpioMode eMode_p)
 
 void piIoComm_writeSniff2B(EGpioValue eVal_p, EGpioMode eMode_p)
 {
-	if (piDev_g.machine_type == REVPI_CORE) {
+	if (piDev_g.machine_type == REVPI_CORE ||
+	    piDev_g.machine_type == REVPI_CORE_SE) {
 		piIoComm_writeSniff(piCore_g.gpio_sniff2b, eVal_p, eMode_p);
 #ifdef DEBUG_GPIO
 		pr_info("sniff2B: mode %d value %d\n", (int)eMode_p, (int)eVal_p);
@@ -476,7 +478,8 @@ EGpioValue piIoComm_readSniff1A()
 
 EGpioValue piIoComm_readSniff1B()
 {
-	if (piDev_g.machine_type == REVPI_CORE) {
+	if (piDev_g.machine_type == REVPI_CORE ||
+	    piDev_g.machine_type == REVPI_CORE_SE) {
 		EGpioValue v = piIoComm_readSniff(piCore_g.gpio_sniff1b);
 #ifdef DEBUG_GPIO
 		pr_info("sniff1B: input value %d\n", (int)v);
@@ -497,7 +500,8 @@ EGpioValue piIoComm_readSniff2A()
 
 EGpioValue piIoComm_readSniff2B()
 {
-	if (piDev_g.machine_type == REVPI_CORE) {
+	if (piDev_g.machine_type == REVPI_CORE ||
+	    piDev_g.machine_type == REVPI_CORE_SE) {
 		EGpioValue v = piIoComm_readSniff(piCore_g.gpio_sniff2b);
 #ifdef DEBUG_GPIO
 		pr_info("sniff2B: input value %d\n", (int)v);

--- a/revpi_core.c
+++ b/revpi_core.c
@@ -220,7 +220,8 @@ static void deinit_sniff_gpios(void)
 	piIoComm_writeSniff1A(enGpioValue_Low, enGpioMode_Input);
 	piIoComm_writeSniff2A(enGpioValue_Low, enGpioMode_Input);
 
-	if (piDev_g.machine_type == REVPI_CORE) {
+	if (piDev_g.machine_type == REVPI_CORE ||
+	    piDev_g.machine_type == REVPI_CORE_SE) {
 		piIoComm_writeSniff1B(enGpioValue_Low, enGpioMode_Input);
 		piIoComm_writeSniff2B(enGpioValue_Low, enGpioMode_Input);
 	}
@@ -255,7 +256,8 @@ static int init_sniff_gpios(struct platform_device *pdev)
 	piCore_g.gpio_sniff1a = descs->desc[0];
 	piCore_g.gpio_sniff2a = descs->desc[1];
 
-	if (piDev_g.machine_type == REVPI_CORE) {
+	if (piDev_g.machine_type == REVPI_CORE ||
+	    piDev_g.machine_type == REVPI_CORE_SE) {
 		descs = devm_gpiod_get_array(&pdev->dev, "right-sniff", GPIOD_IN);
 		if (IS_ERR(descs)) {
 			dev_err(&pdev->dev, "Failed to get right sniff gpios\n");

--- a/revpi_core.c
+++ b/revpi_core.c
@@ -306,7 +306,8 @@ static int init_gpios(struct platform_device *pdev)
 		return ret;
 	}
 
-	if (piDev_g.machine_type == REVPI_CONNECT) {
+	if (piDev_g.machine_type == REVPI_CONNECT ||
+	    piDev_g.machine_type == REVPI_CONNECT_SE) {
 		ret = init_connect_gpios(pdev);
 		if (ret) {
 			dev_err(piDev_g.dev, "Failed to init connect gpios: %i\n",


### PR DESCRIPTION
following changes are made for Core SE and Connect SE:
1. add SE device to revpi_machine
2. set the machine_type in piControlInit()
3. check machine_type, if not SE call revpi_gate_init();
4. add code for Connect SE in every appearance of REVPI_CONNECT
5. add code for Core SE in every appearance of REVPI_CORE