### PR TITLE
piControl: use serdev based revpi-comm device for RS485 communication

### DIFF
--- a/piAIOComm.c
+++ b/piAIOComm.c
@@ -32,14 +32,6 @@
 
 #include <linux/module.h>	// included for all kernel modules
 #include <linux/kernel.h>
-#include <linux/uaccess.h>
-#include <linux/fcntl.h>
-#include <linux/termios.h>
-#include <linux/syscalls.h>
-#include <asm/uaccess.h>
-#include <linux/fs.h>
-#include <linux/kthread.h>
-#include <linux/gpio.h>
 
 #include <project.h>
 #include <common_define.h>

--- a/piDIOComm.c
+++ b/piDIOComm.c
@@ -32,14 +32,6 @@
 
 #include <linux/module.h>	// included for all kernel modules
 #include <linux/kernel.h>
-#include <linux/uaccess.h>
-#include <linux/fcntl.h>
-#include <linux/termios.h>
-#include <linux/syscalls.h>
-#include <asm/uaccess.h>
-#include <linux/fs.h>
-#include <linux/kthread.h>
-#include <linux/gpio.h>
 
 #include <project.h>
 #include <common_define.h>

--- a/piIOComm.h
+++ b/piIOComm.h
@@ -63,21 +63,12 @@ typedef enum _EGpioMode
     enGpioMode_Output,
 } EGpioMode;
 
-extern struct file *piIoComm_fd_m;
-extern int piIoComm_timeoutCnt_m;
-
-int piIoComm_open_serial(void);
 int piIoComm_send(INT8U *buf_p, INT16U i16uLen_p);
 int piIoComm_recv(INT8U *buf_p, INT16U i16uLen_p);	// using default timeout REV_PI_IO_TIMEOUT
 int piIoComm_recv_timeout(INT8U * buf_p, INT16U i16uLen_p, INT16U timeout_p);
 bool piIoComm_response_valid(SIOGeneric *resp, u8 expected_addr,
 			     u8 expected_len);
-int UartThreadProc ( void *pArg);
-
 INT8U piIoComm_Crc8(INT8U *pi8uFrame_p, INT16U i16uLen_p);
-
-int  piIoComm_init(void);
-void piIoComm_finish(void);
 
 void piIoComm_writeSniff1A(EGpioValue eVal_p, EGpioMode eMode_p);
 void piIoComm_writeSniff1B(EGpioValue eVal_p, EGpioMode eMode_p);

--- a/revpi_core.c
+++ b/revpi_core.c
@@ -355,34 +355,16 @@ static int pibridge_probe(struct platform_device *pdev)
 		goto err_deinit_gpios;
 	}
 
-	if (piIoComm_init()) {
-		pr_err("open serial port failed\n");
-		ret = -EFAULT;
-		goto err_release_fw;
-	}
-	/* run threads */
+	/* run thread */
 	ret = set_kthread_prios(revpi_core_kthread_prios);
 	if (ret)
-		goto err_close_serial;
-
-	piCore_g.pUartThread = kthread_run(&UartThreadProc, (void *)NULL, "piControl Uart");
-	if (IS_ERR(piCore_g.pUartThread)) {
-		pr_err("kthread_run(uart) failed\n");
-		ret = PTR_ERR(piCore_g.pUartThread);
-		goto err_close_serial;
-	}
-	param.sched_priority = RT_PRIO_UART;
-	sched_setscheduler(piCore_g.pUartThread, SCHED_FIFO, &param);
-	if (ret) {
-		pr_err("cannot set rt prio of uart thread\n");
-		goto err_stop_uart_thread;
-	}
+		goto err_release_fw;
 
 	piCore_g.pIoThread = kthread_run(&piIoThread, NULL, "piControl I/O");
 	if (IS_ERR(piCore_g.pIoThread)) {
 		pr_err("kthread_run(io) failed\n");
 		ret = PTR_ERR(piCore_g.pIoThread);
-		goto err_stop_uart_thread;
+		goto err_release_fw;
 	}
 	param.sched_priority = RT_PRIO_BRIDGE;
 	ret = sched_setscheduler(piCore_g.pIoThread, SCHED_FIFO, &param);
@@ -395,10 +377,6 @@ static int pibridge_probe(struct platform_device *pdev)
 
 err_stop_io_thread:
 	kthread_stop(piCore_g.pIoThread);
-err_stop_uart_thread:
-	kthread_stop(piCore_g.pUartThread);
-err_close_serial:
-	piIoComm_finish();
 err_release_fw:
 	revpi_release_firmware(piCore_g.fw);
 err_deinit_gpios:
@@ -409,12 +387,7 @@ err_deinit_gpios:
 
 static int pibridge_remove(struct platform_device *pdev)
 {
-	/* tell UART thread to cancel the main loop */
-	send_sig(SIGTERM, piCore_g.pUartThread, 1);
-
 	kthread_stop(piCore_g.pIoThread);
-	kthread_stop(piCore_g.pUartThread);
-	piIoComm_finish();
 	revpi_release_firmware(piCore_g.fw);
 	deinit_gpios();
 

--- a/revpi_core.h
+++ b/revpi_core.h
@@ -91,10 +91,6 @@ typedef struct _SRevPiCore {
 	INT16U i16uRecvDataLenGateTel;
 	int statusGateTel;
 
-	// piUart thread
-	struct task_struct *pUartThread;
-	struct semaphore uartSem;
-
 	// piIO thread
 	struct task_struct *pIoThread;
 	struct hrtimer ioTimer;


### PR DESCRIPTION
There is a serdev implementation for the RS485 piBridge-communication
available. Use that instead of establishing an own serial connection in
piControl. For now we only replace the low-level functions with
pibridge_send() and pibridge_recv_timeout() to keep code changes minimal.
An exception is the use of pibridge_req_gate_tmt() which covers a hole
transaction (request and reception of data with consecutive check of
received data; in a later step only high-level functions that cover
complete transactions should be used).

Clean up the code and remove everything that is not needed any longer,
especially the UART thread and the related data structures which are now
replaced by the functionality implemented in the serdev module.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>