### PR TITLE
piControl: ensure setting I/O processing state is threadsafe

### DIFF
--- a/PiBridgeMaster.c
+++ b/PiBridgeMaster.c
@@ -801,7 +801,7 @@ int PiBridgeMaster_Run(void)
 
 	rt_mutex_unlock(&piCore_g.lockBridgeState);
 
-	if (piDev_g.stopIO) {
+	if (test_bit(PICONTROL_DEV_FLAG_STOP_IO, &piDev_g.flags)) {
 		revpi_power_led_red_set(REVPI_POWER_LED_FLICKR);
 	} else  {
 		if (piCore_g.eBridgeState == piBridgeRun) {
@@ -868,7 +868,7 @@ int PiBridgeMaster_Run(void)
 
 	if (piCore_g.eBridgeState == piBridgeRun) {
 		//flip_process_image(&piCore_g.image, RevPiDevice_getCoreOffset());
-		if (piDev_g.stopIO == false) {
+		if (!test_bit(PICONTROL_DEV_FLAG_STOP_IO, &piDev_g.flags)) {
 			INT8U *p1, *p2;
 			SRevPiCoreImage *pI1, *pI2;
 			p1 = piDev_g.ai8uPI + RevPiDevice_getCoreOffset();

--- a/piAIOComm.c
+++ b/piAIOComm.c
@@ -368,7 +368,7 @@ INT32U piAIOComm_sendCyclicTelegram(INT8U i8uDevice_p)
 	len_l = sizeof(data_out);
 	i8uAddress = RevPiDevice_getDev(i8uDevice_p)->i8uAddress;
 
-	if (piDev_g.stopIO == false) {
+	if (!test_bit(PICONTROL_DEV_FLAG_STOP_IO, &piDev_g.flags)) {
 		my_rt_mutex_lock(&piDev_g.lockPI);
 		memcpy(data_out, piDev_g.ai8uPI + RevPiDevice_getDev(i8uDevice_p)->i16uOutputOffset, len_l);
 		rt_mutex_unlock(&piDev_g.lockPI);
@@ -404,7 +404,8 @@ INT32U piAIOComm_sendCyclicTelegram(INT8U i8uDevice_p)
 			if (piIoComm_response_valid(&sResponse_l, i8uAddress, len_l)) {
 				memcpy(data_in, sResponse_l.ai8uData, len_l);
 
-				if (piDev_g.stopIO == false) {
+				if (!test_bit(PICONTROL_DEV_FLAG_STOP_IO,
+					     &piDev_g.flags)) {
 					my_rt_mutex_lock(&piDev_g.lockPI);
 					memcpy(piDev_g.ai8uPI + RevPiDevice_getDev(i8uDevice_p)->i16uInputOffset, data_in,
 					       sizeof(data_in));

--- a/piControlMain.c
+++ b/piControlMain.c
@@ -284,7 +284,7 @@ static int __init piControlInit(void)
 	/* init some data */
 	rt_mutex_init(&piDev_g.lockPI);
 	rt_mutex_init(&piDev_g.lockIoctl);
-	piDev_g.stopIO = false;
+	clear_bit(PICONTROL_DEV_FLAG_STOP_IO, &piDev_g.flags);
 
 	piDev_g.tLastOutput1 = ktime_set(0, 0);
 	piDev_g.tLastOutput2 = ktime_set(0, 0);
@@ -1416,8 +1416,8 @@ static long piControlIoctl(struct file *file, unsigned int prg_nr, unsigned long
 
 	case KB_STOP_IO:
 		{
-			// parameter = 0: stop I/Os
-			// parameter = 1: start I/Os
+			// parameter = 0: start I/Os
+			// parameter = 1: stop I/Os
 			// parameter = 2: toggle I/Os
 			u32 data;
 
@@ -1430,11 +1430,18 @@ static long piControlIoctl(struct file *file, unsigned int prg_nr, unsigned long
 			}
 
 			if (data == 2) {
-				piDev_g.stopIO = !piDev_g.stopIO;
+				change_bit(PICONTROL_DEV_FLAG_STOP_IO,
+					   &piDev_g.flags);
 			} else {
-				piDev_g.stopIO = data ? true : false;
+				if (data)
+					set_bit(PICONTROL_DEV_FLAG_STOP_IO,
+						&piDev_g.flags);
+				else
+					clear_bit(PICONTROL_DEV_FLAG_STOP_IO,
+						  &piDev_g.flags);
 			}
-			status = piDev_g.stopIO;
+			status = test_bit(PICONTROL_DEV_FLAG_STOP_IO,
+					  &piDev_g.flags) ? 1 : 0;
 		}
 		break;
 

--- a/piControlMain.h
+++ b/piControlMain.h
@@ -74,7 +74,8 @@ typedef struct spiControlDev {
 	INT8U ai8uPI[KB_PI_LEN];
 	INT8U ai8uPIDefault[KB_PI_LEN];
 	struct rt_mutex lockPI;
-	bool stopIO;
+#define PICONTROL_DEV_FLAG_STOP_IO		(1 << 0)
+	unsigned long flags;
 	piDevices *devs;
 	piEntries *ent;
 	piCopylist *cl;

--- a/piDIOComm.c
+++ b/piDIOComm.c
@@ -177,7 +177,7 @@ INT32U piDIOComm_sendCyclicTelegram(INT8U i8uDevice_p)
 	len_l = 18;
 	i8uAddress = RevPiDevice_getDev(i8uDevice_p)->i8uAddress;
 
-	if (piDev_g.stopIO == false) {
+	if (!test_bit(PICONTROL_DEV_FLAG_STOP_IO, &piDev_g.flags)) {
 		rt_mutex_lock(&piDev_g.lockPI);
 		memcpy(data_out, piDev_g.ai8uPI + RevPiDevice_getDev(i8uDevice_p)->i16uOutputOffset, len_l);
 		rt_mutex_unlock(&piDev_g.lockPI);

--- a/process_image.h
+++ b/process_image.h
@@ -80,7 +80,7 @@ static __always_inline int test_bit_in_byte(u8 nr, u8 * addr)
 
 #define flip_process_image(shadow, offset)						\
 {											\
-	if (piDev_g.stopIO == false) {							\
+	if (!test_bit(PICONTROL_DEV_FLAG_STOP_IO, &piDev_g.flags)) {			\
 		if (((typeof(shadow))(piDev_g.ai8uPI + (offset))) == 0 || (shadow) == 0) \
 			pr_err("NULL pointer: %p %p\n", ((typeof(shadow))(piDev_g.ai8uPI + (offset))), (shadow)); \
 		my_rt_mutex_lock(&piDev_g.lockPI);					\

--- a/revpi_core.c
+++ b/revpi_core.c
@@ -166,7 +166,8 @@ static int piIoThread(void *data)
 				// the logiRTS must have been stopped or crashed
 				// -> set all outputs to 0
 				pr_info("logiRTS timeout, set all output to 0\n");
-				if (piDev_g.stopIO == false) {
+				if (!test_bit(PICONTROL_DEV_FLAG_STOP_IO,
+					&piDev_g.flags)) {
 					my_rt_mutex_lock(&piDev_g.lockPI);
 					for (i = 0; i < piDev_g.cl->i16uNumEntries; i++) {
 						uint16_t len = piDev_g.cl->ent[i].i16uLength;

--- a/revpi_gate.c
+++ b/revpi_gate.c
@@ -129,7 +129,8 @@ static void revpi_gate_destroy_work(struct work_struct *work)
 	cancel_delayed_work_sync(&conn->send_work);
 	cancel_delayed_work(&conn->destroy_work);
 
-	if (conn->revpi_dev && !piDev_g.stopIO) {
+	if (conn->revpi_dev &&
+	    !test_bit(PICONTROL_DEV_FLAG_STOP_IO, &piDev_g.flags)) {
 		conn->revpi_dev->i8uModuleState = FBSTATE_LINK;
 		rt_mutex_lock(&piDev_g.lockPI);
 		memset(conn->in, 0, conn->in_len);
@@ -245,7 +246,8 @@ static void revpi_gate_send_work(struct work_struct *work)
 	if (!skb)
 		return;
 
-	if (conn->revpi_dev && !piDev_g.stopIO) {
+	if (conn->revpi_dev &&
+	    !test_bit(PICONTROL_DEV_FLAG_STOP_IO, &piDev_g.flags)) {
 		rt_mutex_lock(&piDev_g.lockPI);
 		memcpy(al->i8uData, conn->out, conn->out_len);
 		rt_mutex_unlock(&piDev_g.lockPI);
@@ -316,7 +318,8 @@ static int revpi_gate_process_cyclicpd(struct sk_buff *rcv,
 			goto drop;
 	}
 
-	if (conn->revpi_dev && !piDev_g.stopIO) {
+	if (conn->revpi_dev &&
+	    !test_bit(PICONTROL_DEV_FLAG_STOP_IO, &piDev_g.flags)) {
 		conn->revpi_dev->i8uModuleState = rcv_al->i8uFieldbusStatus;
 		rt_mutex_lock(&piDev_g.lockPI);
 		memcpy(conn->in + rcv_al->i16uOffset, rcv_al->i8uData,


### PR DESCRIPTION
The piControl kernel modules uses a global bool variable “piDev_g.stopIO” which can be set by means of ioctls to steer the input/output value processing: if the variable is set to “false” input and output are processed as usual, while a value of “true” results in changing of input/output values being supressed (i.e. not passed from/to userspace).

The problem is that the variable is not threadsafe. This means that if it is changed by a userspace process the set value may or may not be visible to the processor that is currently processing the input/output (loop). In the worst case this may result in setting of the variable having no effect.

So ensure the data integrity by using the threadsafe bitoperations provided by the kernel. For this turn the boolean value into a unsigned long and define the bit to determine if I/O processing is enabled or not.

By doing this also correct a related comment in the source code.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>