### PR TITLE
Connect SE: Make led A3 usable via process image [REVPI-3091]

### DIFF
--- a/revpi_common.c
+++ b/revpi_common.c
@@ -43,6 +43,7 @@ void revpi_led_trigger_event(u16 led_prev, u16 led)
 	}
 
 	if ((piDev_g.machine_type == REVPI_CONNECT) ||
+	     piDev_g.machine_type == REVPI_CONNECT_SE ||
 	    (piDev_g.machine_type == REVPI_FLAT)) {
 		if (changed & PICONTROL_LED_A3_GREEN) {
 			led_trigger_event(&piDev_g.a3_green, (led & PICONTROL_LED_A3_GREEN) ? LED_FULL : LED_OFF);


### PR DESCRIPTION
In the initial commit [1] that introduced support for the RevPi Connect SE, the LED A3 was mistakenly forgotten. Fix this by adding a third machine type entry 'REVPI_CONNECT_SE' in the if clause.

[1] 2fdd1f4adab8e3e095808704b71e3ae2b313da6e