### PR TITLE
piTest: Add Connect 4 as known device

### DIFF
--- a/common_define.h
+++ b/common_define.h
@@ -124,6 +124,7 @@ typedef struct S_KUNBUS_REV_NUMBER {
 #define KUNBUS_FW_DESCR_TYP_PI_CON_BT                             111
 #define KUNBUS_FW_DESCR_TYP_PI_MIO                                118
 #define KUNBUS_FW_DESCR_TYP_PI_FLAT                               135
+#define KUNBUS_FW_DESCR_TYP_PI_CONNECT_4                          136
 
 #define KUNBUS_FW_DESCR_TYP_INTERN                                  0xffff
 #define KUNBUS_FW_DESCR_TYP_UNDEFINED                               0xffff

--- a/piTest/piTest.c
+++ b/piTest/piTest.c
@@ -150,6 +150,8 @@ char *getModuleName(uint16_t moduletype)
 		return "RevPi MIO";
 	case 135:
 		return "RevPi Flat";
+	case 136:
+		return "RevPi Connect 4";
 
 	case PICONTROL_SW_MODBUS_TCP_SLAVE:
 		return "ModbusTCP Slave Adapter";


### PR DESCRIPTION
Besides the implementation of the Connect 4 support in piControl, we need to add the device as known in piTest.