### PR TITLE
piControl: increase priority of io-thread

### DIFF
--- a/project.h
+++ b/project.h
@@ -92,7 +92,14 @@
 #define DEBUG_DEVICE_IO
 
 #define RT_PRIO_UART    39
-#define RT_PRIO_BRIDGE  38
+/*
+ * The priority has to be at least 54 (same as SPI thread), otherwise lots
+ * of UART reception errors are observed. The reason for this effect is not
+ * yet completely clear, presumably the UART has to switch as quickly as
+ * possible from data transmission to data reception to avoid errors during
+ * piBridge communication.
+*/
+#define RT_PRIO_BRIDGE  54
 #define RT_PRIO_GATE    37
 
 #ifdef DEBUG_SERIALCOMM


### PR DESCRIPTION
During the piBridge communication lots of messages are logged in the kernel log that indicate UART data reception errors like parity, frame and (occassionally) overflow errors.

As it turned out increasing the realtime priority of the thread that handles the piBridge communication to 54 (which is the same as the SPI thread priority) fixes these issues.

Bevore this change an error rate (ratio of total errors to received bytes) of 0,000563221 (i.e. 0,056%) could be observerd during a 45 minute test. After this change the error rate is decreased to 0 (i.e. no errors at all). This rate is even below the error rate that is observed with the 4.19 Revpi kernel (0,0000262%)

NOTE: The reason for this effect is still not completely clear, presumably the UART has to switch as quickly as possible from transmitting to receiving data.