### PR TITLE
Remove unused constat REV_PI_TTY_DEVICE

### DIFF
--- a/piIOComm.h
+++ b/piIOComm.h
@@ -40,8 +40,6 @@
 #define REV_PI_IO_TIMEOUT           10         // msec
 #define REV_PI_RECV_BUFFER_SIZE     100
 
-#define REV_PI_TTY_DEVICE	"/dev/ttyAMA0"
-
 enum IOSTATE {
     /* physically not connected */
     IOSTATE_OFFLINE   = 0x00,


### PR DESCRIPTION
REV_PI_TTY_DEVICE is no longer necessary since UART access has been changed to serdev.