### PR TITLE
fix: Too long high pulse on the left ACK pin on Connect 4 (revpi-6.1) [REVPI-3644]

### DIFF
--- a/PiBridgeMaster.c
+++ b/PiBridgeMaster.c
@@ -314,7 +314,17 @@ int PiBridgeMaster_Run(void)
 				piIoComm_writeSniff2A(enGpioValue_High, enGpioMode_Output);
 				piIoComm_writeSniff2B(enGpioValue_High, enGpioMode_Output);
 
-				usleep_range(9000, 9000);
+				/*
+				 * This delay defines the length of the high
+				 * pulse at the begin of the present signaling.
+				 * The module (at least the DIO module) expects
+				 * this pulse to be between 7.5 and 9.5 ms.
+				 * Pushing the delay to the upper limit might
+				 * cause issues. It might take some time to
+				 * switch the pin. Especially on devices which
+				 * use an io expander like the Connect 4.
+				 */
+				usleep_range(8500, 8500);
 
 				piIoComm_writeSniff2A(enGpioValue_Low, enGpioMode_Input);
 				piIoComm_writeSniff2B(enGpioValue_Low, enGpioMode_Input);


### PR DESCRIPTION
The signaling on the piBridge starts with the ACK pins (2A and 2B). The pins are driven high in output mode. We are waiting 9 ms then the pins are configured to input mode. The signal is then pulled down by an external resistor to ground level.

On the Module side the transition from low to high is the beginning of the initialization sequence. After this the ACK pin must stay high for >= 7.5 ms and <= 9.5 ms. If the level drops earlier or later the module will go back to the start of the initialization sequence and it will wait for a low -> high transition on the ACK pin.

On the Connect 4 it happens that the transition from high to low takes longer. As the current levels are not dropping as fast as expected. In some cases it takes more then 0.5 ms. And as we wait 9 ms until we switch the pin from output high to input it takes over all > 9.5ms.

To fix the issue with the Connect 4 and make this more robust, we should reduce the delay to at least 8.5 ms. This is in the middle of the acceptable range of 7.5 to 9.5 ms.